### PR TITLE
Update ID generation and timing logging

### DIFF
--- a/Sources/PromotedAIMetricsSDK/MetricsLogger+Helpers.swift
+++ b/Sources/PromotedAIMetricsSDK/MetricsLogger+Helpers.swift
@@ -4,9 +4,7 @@ public extension MetricsLogger {
   // MARK: - Impression logging helper methods
   /// Logs an impression for the given content.
   @objc func logImpression(content: Content) {
-    if let id = content.contentID {
-      logImpression(contentID: id, insertionID: content.insertionID)
-    }
+    logImpression(contentID: content.contentID, insertionID: content.insertionID)
   }
 
   // MARK: - Action logging helper methods

--- a/Sources/PromotedAIMetricsSDK/MetricsLogger+Helpers.swift
+++ b/Sources/PromotedAIMetricsSDK/MetricsLogger+Helpers.swift
@@ -4,7 +4,9 @@ public extension MetricsLogger {
   // MARK: - Impression logging helper methods
   /// Logs an impression for the given content.
   @objc func logImpression(content: Content) {
-    if let id = content.contentID { logImpression(contentID: id) }
+    if let id = content.contentID {
+      logImpression(contentID: id, insertionID: content.insertionID)
+    }
   }
 
   // MARK: - Action logging helper methods

--- a/Sources/PromotedAIMetricsSDK/MetricsLogger.swift
+++ b/Sources/PromotedAIMetricsSDK/MetricsLogger.swift
@@ -187,6 +187,12 @@ public class MetricsLogger: NSObject {
     if let id = logUserID { userInfo.logUserID = id }
     return userInfo
   }
+  
+  private func timingMessage() -> Common_Timing {
+    var timing = Common_Timing()
+    timing.clientLogTimestamp = clock.nowMillis
+    return timing
+  }
 
   private static func propertiesWrapperMessage(_ message: Message?)
       -> Common_Properties? {
@@ -219,6 +225,7 @@ public extension MetricsLogger {
   ///   - data: Client-specific message
   func logUser(properties: Message? = nil) {
     var user = Event_User()
+    user.timing = timingMessage()
     if let properties = Self.propertiesWrapperMessage(properties) {
       user.properties = properties
     }
@@ -228,6 +235,7 @@ public extension MetricsLogger {
   func logSession(properties: Message? = nil) {
     assert(sessionID != nil, "Call startSession* before any log* methods")
     var session = Event_Session()
+    session.timing = timingMessage()
     if let id = sessionID { session.sessionID = id }
     session.startEpochMillis = clock.nowMillis
     if let properties = Self.propertiesWrapperMessage(properties) {
@@ -246,21 +254,23 @@ public extension MetricsLogger {
   ///   - contentID: Content ID from which to derive `impressionID`
   ///   - insertionID: Insertion ID as provided by Promoted
   ///   - data: Client-specific message
-  func logImpression(contentID: String,
+  func logImpression(contentID: String? = nil,
                      insertionID: String? = nil,
                      requestID: String? = nil,
                      viewID: String? = nil,
                      properties: Message? = nil) {
+    let optionalID = idMap.impressionIDOrNil(insertionID: insertionID,
+                                             contentID: contentID,
+                                             logUserID: logUserID)
+    guard let impressionID = optionalID else { return }
     var impression = Event_Impression()
-    let mappedContentID = idMap.impressionIDOrNil(insertionID: insertionID,
-                                                  contentID: contentID,
-                                                  logUserID: logUserID)
-    if let id = mappedContentID { impression.impressionID = id }
+    impression.timing = timingMessage()
+    impression.impressionID = impressionID
     if let id = insertionID { impression.insertionID = id }
     if let id = requestID { impression.requestID = id }
     if let id = sessionID { impression.sessionID = id }
     if let id = viewID { impression.viewID = id }
-    impression.contentID = idMap.contentID(clientID: contentID)
+    if let id = contentID { impression.contentID = idMap.contentID(clientID: id) }
     if let properties = Self.propertiesWrapperMessage(properties) {
       impression.properties = properties
     }
@@ -292,6 +302,7 @@ public extension MetricsLogger {
                  elementID: String? = nil,
                  properties: Message? = nil) {
     var action = Event_Action()
+    action.timing = timingMessage()
     action.actionID = idMap.actionID()
     let impressionID = idMap.impressionIDOrNil(insertionID: insertionID,
                                                contentID: contentID,
@@ -334,6 +345,7 @@ public extension MetricsLogger {
                useCase: UseCase? = nil,
                properties: Message? = nil) {
     var view = Event_View()
+    view.timing = timingMessage()
     view.viewID = idMap.viewID()
     if let id = sessionID { view.sessionID = id }
     view.name = name

--- a/Sources/PromotedAIMetricsSDK/MetricsLogger.swift
+++ b/Sources/PromotedAIMetricsSDK/MetricsLogger.swift
@@ -175,7 +175,7 @@ public class MetricsLogger: NSObject {
       }
     }
     store.userID = userID
-    let newLogUserID = idMap.logUserID(userID: userID)
+    let newLogUserID = idMap.logUserID()
     store.logUserID = newLogUserID
     self.logUserID = newLogUserID
   }
@@ -252,13 +252,15 @@ public extension MetricsLogger {
                      viewID: String? = nil,
                      properties: Message? = nil) {
     var impression = Event_Impression()
-    let mappedContentID = idMap.impressionID(contentID: contentID)
-    impression.impressionID = mappedContentID
+    let mappedContentID = idMap.impressionIDOrNil(insertionID: insertionID,
+                                                  contentID: contentID,
+                                                  logUserID: logUserID)
+    if let id = mappedContentID { impression.impressionID = id }
     if let id = insertionID { impression.insertionID = id }
     if let id = requestID { impression.requestID = id }
     if let id = sessionID { impression.sessionID = id }
     if let id = viewID { impression.viewID = id }
-    impression.contentID = mappedContentID
+    impression.contentID = idMap.contentID(clientID: contentID)
     if let properties = Self.propertiesWrapperMessage(properties) {
       impression.properties = properties
     }
@@ -291,7 +293,9 @@ public extension MetricsLogger {
                  properties: Message? = nil) {
     var action = Event_Action()
     action.actionID = idMap.actionID()
-    let impressionID = idMap.impressionIDOrNil(contentID: contentID)
+    let impressionID = idMap.impressionIDOrNil(insertionID: insertionID,
+                                                  contentID: contentID,
+                                                  logUserID: logUserID)
     if let id = impressionID { action.impressionID = id }
     if let id = insertionID { action.insertionID = id }
     if let id = requestID { action.requestID = id }
@@ -330,7 +334,7 @@ public extension MetricsLogger {
                useCase: UseCase? = nil,
                properties: Message? = nil) {
     var view = Event_View()
-    view.viewID = idMap.viewID(viewName: name)
+    view.viewID = idMap.viewID()
     if let id = sessionID { view.sessionID = id }
     view.name = name
     if let use = useCase?.protoValue { view.useCase = use }

--- a/Sources/PromotedAIMetricsSDK/MetricsLogger.swift
+++ b/Sources/PromotedAIMetricsSDK/MetricsLogger.swift
@@ -294,8 +294,8 @@ public extension MetricsLogger {
     var action = Event_Action()
     action.actionID = idMap.actionID()
     let impressionID = idMap.impressionIDOrNil(insertionID: insertionID,
-                                                  contentID: contentID,
-                                                  logUserID: logUserID)
+                                               contentID: contentID,
+                                               logUserID: logUserID)
     if let id = impressionID { action.impressionID = id }
     if let id = insertionID { action.insertionID = id }
     if let id = requestID { action.requestID = id }

--- a/Sources/PromotedAIMetricsSDK/Model/IDMap.swift
+++ b/Sources/PromotedAIMetricsSDK/Model/IDMap.swift
@@ -19,8 +19,10 @@ public protocol IDMap {
   func sessionID() -> String
 
   /// Given possible input sources, generate a server-side impression ID.
-  /// Returns `nil` if no impression ID is generated from inputs.
-  ///
+  /// If `insertionID` is not `nil`, then generates an impression ID based
+  /// on `insertionID`. If `contentID` and `logUserID` are both not `nil`,
+  /// then generates an impression ID based on a combination of those two
+  /// IDs. Otherwise, returns `nil`.
   func impressionIDOrNil(insertionID: String?,
                          contentID: String?,
                          logUserID: String?) -> String?

--- a/Sources/PromotedAIMetricsSDK/Model/IDMap.swift
+++ b/Sources/PromotedAIMetricsSDK/Model/IDMap.swift
@@ -14,29 +14,26 @@ public protocol IDMap {
   /// Given a client-side user ID, generate a log user ID which
   /// is used to track the the current session without exposing
   /// the underlying user ID.
-  /// Returns the null UUID string when passed `nil`.
-  func logUserID(userID: String?) -> String
+  func logUserID() -> String
   
   func sessionID() -> String
 
-  /// Given a client-side ID, generate a server-side impression ID.
-  /// Returns the null UUID string when passed `nil`.
-  func impressionID(contentID: String?) -> String
-  
+  /// Given possible input sources, generate a server-side impression ID.
+  /// Returns `nil` if no impression ID is generated from inputs.
+  ///
+  func impressionIDOrNil(insertionID: String?,
+                         contentID: String?,
+                         logUserID: String?) -> String?
+
+  /// Given a client's content ID, generates a content ID to log.
+  func contentID(clientID: String) -> String
+
   /// Generates a new click ID.
   func actionID() -> String
   
   /// Generates a new view ID.
   /// Returns the null UUID string when passed `nil`.
-  func viewID(viewName: String?) -> String
-}
-
-public extension IDMap {
-  /// Same as `impressionID(clientID:)`, but returns `nil` on `nil` input.
-  func impressionIDOrNil(contentID: String?) -> String? {
-    if let contentID = contentID { return impressionID(contentID: contentID) }
-    return nil
-  }
+  func viewID() -> String
 }
 
 // MARK: -
@@ -54,7 +51,7 @@ open class AbstractIDMap: IDMap {
     return ""
   }
 
-  open func logUserID(userID: String?) -> String {
+  open func logUserID() -> String {
     return UUID().uuidString
   }
   
@@ -62,16 +59,29 @@ open class AbstractIDMap: IDMap {
     return UUID().uuidString
   }
 
-  open func impressionID(contentID: String?) -> String {
-    return deterministicUUIDString(value: contentID)
+  open func impressionIDOrNil(insertionID: String?,
+                              contentID: String?,
+                              logUserID: String?) -> String? {
+    if let insertionID = insertionID {
+      return deterministicUUIDString(value: insertionID)
+    }
+    if let contentID = contentID, let logUserID = logUserID {
+      let combined = contentID + logUserID
+      return deterministicUUIDString(value: combined)
+    }
+    return nil
+  }
+  
+  open func contentID(clientID: String) -> String {
+    return deterministicUUIDString(value: clientID)
   }
   
   open func actionID() -> String {
     return UUID().uuidString
   }
   
-  open func viewID(viewName: String?) -> String {
-    return deterministicUUIDString(value: viewName)
+  open func viewID() -> String {
+    return UUID().uuidString
   }
 }
 

--- a/Sources/PromotedAIMetricsSDK/Model/IDMap.swift
+++ b/Sources/PromotedAIMetricsSDK/Model/IDMap.swift
@@ -16,6 +16,7 @@ public protocol IDMap {
   /// the underlying user ID.
   func logUserID() -> String
   
+  /// Generates a new session ID.
   func sessionID() -> String
 
   /// Given possible input sources, generate a server-side impression ID.

--- a/Sources/TestHelpers/FakeIDMap.swift
+++ b/Sources/TestHelpers/FakeIDMap.swift
@@ -2,16 +2,45 @@ import Foundation
 import PromotedAIMetricsSDK
 
 public class FakeIDMap: AbstractIDMap {
+  public var incrementCounts: Bool = false
+  
   public override func deterministicUUIDString(value: String?) -> String {
     return String(format: "%02x", (value?.hashValue ?? 0))
   }
-  public override func logUserID(userID: String?) -> String {
-    return deterministicUUIDString(value: userID)
+
+  public private(set) var logUserIDCount: Int = 0
+  public override func logUserID() -> String {
+    if incrementCounts {
+      logUserIDCount += 1
+      return "fake-log-user-id-\(logUserIDCount)"
+    }
+    return "fake-log-user-id"
   }
+
+  public private(set) var actionIDCount: Int = 0
   public override func actionID() -> String {
+    if incrementCounts {
+      actionIDCount += 1
+      return "fake-action-id-\(actionIDCount)"
+    }
     return "fake-action-id"
   }
+
+  public private(set) var sessionIDCount: Int = 0
   public override func sessionID() -> String {
+    if incrementCounts {
+      sessionIDCount += 1
+      return "fake-session-id-\(sessionIDCount)"
+    }
     return "fake-session-id"
+  }
+  
+  public private(set) var viewIDCount: Int = 0
+  public override func viewID() -> String {
+    if incrementCounts {
+      viewIDCount += 1
+      return "fake-view-id-\(viewIDCount)"
+    }
+    return "fake-view-id"
   }
 }

--- a/Tests/PromotedAIMetricsSDKTests/MetricsLoggerTests.swift
+++ b/Tests/PromotedAIMetricsSDKTests/MetricsLoggerTests.swift
@@ -27,6 +27,7 @@ final class MetricsLoggerTests: XCTestCase {
     config!.metricsLoggingURL = "http://fake.promoted.ai/metrics"
     connection = FakeNetworkConnection()
     clock = FakeClock()
+    clock!.advance(to: 123)
     idMap = FakeIDMap()
     store = FakePersistentStore()
     store!.userID = nil
@@ -191,6 +192,9 @@ final class MetricsLoggerTests: XCTestCase {
     XCTAssertTrue(message is Event_User)
     let expectedJSON = """
     {
+      "timing": {
+        "client_log_timestamp": 123000
+      }
     }
     """
     XCTAssertEqual(try Event_User(jsonString: expectedJSON),
@@ -208,6 +212,9 @@ final class MetricsLoggerTests: XCTestCase {
                                                 logUserID: "fake-log-user-id")!
     let expectedJSON = """
     {
+      "timing": {
+        "client_log_timestamp": 123000
+      },
       "impression_id": "\(impressionID)",
       "insertion_id": "insertion!",
       "content_id": "\(idMap!.contentID(clientID: "foobar"))",
@@ -229,6 +236,9 @@ final class MetricsLoggerTests: XCTestCase {
                                                 logUserID: "fake-log-user-id")!
     let expectedJSON = """
     {
+      "timing": {
+        "client_log_timestamp": 123000
+      },
       "impression_id": "\(impressionID)",
       "content_id": "\(idMap!.contentID(clientID: "foobar"))",
       "session_id": "fake-session-id"
@@ -250,6 +260,9 @@ final class MetricsLoggerTests: XCTestCase {
                                                 logUserID: "fake-log-user-id")!
     let expectedJSON = """
     {
+      "timing": {
+        "client_log_timestamp": 123000
+      },
       "action_id": "fake-action-id",
       "impression_id": "\(impressionID)",
       "session_id": "fake-session-id",
@@ -275,6 +288,9 @@ final class MetricsLoggerTests: XCTestCase {
                                                 logUserID: "fake-log-user-id")!
     let expectedJSON = """
     {
+      "timing": {
+        "client_log_timestamp": 123000
+      },
       "action_id": "fake-action-id",
       "impression_id": "\(impressionID)",
       "session_id": "fake-session-id",
@@ -298,6 +314,9 @@ final class MetricsLoggerTests: XCTestCase {
                                                 logUserID: "fake-log-user-id")!
     let expectedJSON = """
     {
+      "timing": {
+        "client_log_timestamp": 123000
+      },
       "action_id": "fake-action-id",
       "impression_id": "\(impressionID)",
       "session_id": "fake-session-id",
@@ -317,6 +336,9 @@ final class MetricsLoggerTests: XCTestCase {
     XCTAssertTrue(message is Event_Action)
     let expectedJSON = """
     {
+      "timing": {
+        "client_log_timestamp": 123000
+      },
       "action_id": "fake-action-id",
       "session_id": "fake-session-id",
       "name": "checkout",
@@ -339,6 +361,9 @@ final class MetricsLoggerTests: XCTestCase {
                                                 logUserID: "fake-log-user-id")!
     let expectedJSON = """
     {
+      "timing": {
+        "client_log_timestamp": 123000
+      },
       "action_id": "fake-action-id",
       "impression_id": "\(impressionID)",
       "session_id": "fake-session-id",
@@ -362,6 +387,9 @@ final class MetricsLoggerTests: XCTestCase {
                                                 logUserID: "fake-log-user-id")!
     let expectedJSON = """
     {
+      "timing": {
+        "client_log_timestamp": 123000
+      },
       "action_id": "fake-action-id",
       "impression_id": "\(impressionID)",
       "session_id": "fake-session-id",
@@ -385,6 +413,9 @@ final class MetricsLoggerTests: XCTestCase {
                                                 logUserID: "fake-log-user-id")!
     let expectedJSON = """
     {
+      "timing": {
+        "client_log_timestamp": 123000
+      },
       "action_id": "fake-action-id",
       "impression_id": "\(impressionID)",
       "session_id": "fake-session-id",
@@ -408,6 +439,9 @@ final class MetricsLoggerTests: XCTestCase {
                                                 logUserID: "fake-log-user-id")!
     let expectedJSON = """
     {
+      "timing": {
+        "client_log_timestamp": 123000
+      },
       "action_id": "fake-action-id",
       "impression_id": "\(impressionID)",
       "session_id": "fake-session-id",
@@ -431,6 +465,9 @@ final class MetricsLoggerTests: XCTestCase {
                                                 logUserID: "fake-log-user-id")!
     let expectedJSON = """
     {
+      "timing": {
+        "client_log_timestamp": 123000
+      },
       "action_id": "fake-action-id",
       "impression_id": "\(impressionID)",
       "session_id": "fake-session-id",
@@ -454,6 +491,9 @@ final class MetricsLoggerTests: XCTestCase {
                                                 logUserID: "fake-log-user-id")!
     let expectedJSON = """
     {
+      "timing": {
+        "client_log_timestamp": 123000
+      },
       "action_id": "fake-action-id",
       "impression_id": "\(impressionID)",
       "session_id": "fake-session-id",
@@ -477,6 +517,9 @@ final class MetricsLoggerTests: XCTestCase {
                                                 logUserID: "fake-log-user-id")!
     let expectedJSON = """
     {
+      "timing": {
+        "client_log_timestamp": 123000
+      },
       "action_id": "fake-action-id",
       "impression_id": "\(impressionID)",
       "session_id": "fake-session-id",
@@ -500,6 +543,9 @@ final class MetricsLoggerTests: XCTestCase {
                                                 logUserID: "fake-log-user-id")!
     let expectedJSON = """
     {
+      "timing": {
+        "client_log_timestamp": 123000
+      },
       "action_id": "fake-action-id",
       "impression_id": "\(impressionID)",
       "session_id": "fake-session-id",
@@ -519,6 +565,9 @@ final class MetricsLoggerTests: XCTestCase {
     XCTAssertTrue(message is Event_Action)
     let expectedJSON = """
     {
+      "timing": {
+        "client_log_timestamp": 123000
+      },
       "action_id": "fake-action-id",
       "session_id": "fake-session-id",
       "name": "sign-in",
@@ -537,6 +586,9 @@ final class MetricsLoggerTests: XCTestCase {
     XCTAssertTrue(message is Event_Action)
     let expectedJSON = """
     {
+      "timing": {
+        "client_log_timestamp": 123000
+      },
       "action_id": "fake-action-id",
       "session_id": "fake-session-id",
       "name": "sign-up",
@@ -556,6 +608,9 @@ final class MetricsLoggerTests: XCTestCase {
     XCTAssertTrue(message is Event_View)
     let expectedJSON = """
     {
+      "timing": {
+        "client_log_timestamp": 123000
+      },
       "view_id": "\(idMap!.viewID())",
       "session_id": "fake-session-id",
       "name": "FakeScreen",


### PR DESCRIPTION
- Make view IDs unique.
- Key impression ID from insertion ID first, if available. If not, use a combination of content ID + log user ID.
- Log timing info in each log message.