### PR TITLE
Expose errors to public clients

### DIFF
--- a/Sources/PromotedCore/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig.swift
@@ -157,10 +157,3 @@ protocol ClientConfigSource {
   var clientConfig: ClientConfig { get }
   var initialConfig: ClientConfig { get }
 }
-
-extension ClientConfig: NSCopying {
-
-  public func copy(with zone: NSZone? = nil) -> Any {
-    return ClientConfig(self)
-  }
-}

--- a/Sources/PromotedCore/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig.swift
@@ -104,6 +104,24 @@ public final class ClientConfig: NSObject {
   @objc public var osLogEnabled: Bool = false
 
   @objc public override init() {}
+  
+  public init(_ config: ClientConfig) {
+    // ClientConfig really should be a struct, but isn't because
+    // of Objective C compatibility.
+    self.loggingEnabled = config.loggingEnabled
+    self.metricsLoggingURL = config.metricsLoggingURL
+    self.metricsLoggingAPIKey = config.metricsLoggingAPIKey
+    self.devMetricsLoggingURL = config.devMetricsLoggingURL
+    self.devMetricsLoggingAPIKey = config.devMetricsLoggingAPIKey
+    self.metricsLoggingWireFormat = config.metricsLoggingWireFormat
+    self.loggingFlushInterval = config.loggingFlushInterval
+    self.scrollTrackerVisibilityThreshold = config.scrollTrackerVisibilityThreshold
+    self.scrollTrackerDurationThreshold = config.scrollTrackerDurationThreshold
+    self.scrollTrackerUpdateFrequency = config.scrollTrackerUpdateFrequency
+    self.xrayEnabled = config.xrayEnabled
+    self.xrayExpensiveThreadCallStacksEnabled = config.xrayExpensiveThreadCallStacksEnabled
+    self.osLogEnabled = config.osLogEnabled
+  }
 
   func bound<T: Comparable>(_ value: inout T, min: T? = nil, max: T? = nil,
                             function: String = #function) {
@@ -138,4 +156,11 @@ public final class ClientConfig: NSObject {
 protocol ClientConfigSource {
   var clientConfig: ClientConfig { get }
   var initialConfig: ClientConfig { get }
+}
+
+extension ClientConfig: NSCopying {
+
+  public func copy(with zone: NSZone? = nil) -> Any {
+    return ClientConfig(self)
+  }
 }

--- a/Sources/PromotedCore/ClientConfigService.swift
+++ b/Sources/PromotedCore/ClientConfigService.swift
@@ -35,7 +35,7 @@ public protocol ClientConfigService: AnyObject {
   func removeClientConfigListener(_ listener: ClientConfigListener)
   
   /// Initiates asynchronous load of client properties.
-  func fetchClientConfig()
+  func fetchClientConfig() throws
 }
 
 protocol ClientConfigServiceSource {
@@ -63,7 +63,7 @@ open class AbstractClientConfigService: ClientConfigService {
     listeners.removeAll(identicalTo: listener)
   }
 
-  open func fetchClientConfig() {
+  open func fetchClientConfig() throws {
     assertionFailure("Don't instantiate AbstractClientConfigService")
   }
 }
@@ -79,7 +79,7 @@ public extension AbstractClientConfigService {
 // MARK: - LocalClientConfigService
 /** Loads from local device. */
 final class LocalClientConfigService: AbstractClientConfigService {
-  public override func fetchClientConfig() {
+  public override func fetchClientConfig() throws {
     // No-op for local config.
   }
 }

--- a/Sources/PromotedCore/Errors.swift
+++ b/Sources/PromotedCore/Errors.swift
@@ -9,7 +9,7 @@ public protocol ErrorListener {
   /// Called once per error after call to Promoted logging finishes.
   /// Internal errors are surfaced to clients as `NSError` (see
   /// `ClientConfigError`).
-  @objc func metricsLoggerDidError(_ error: NSError)
+  @objc func promotedLoggerDidError(_ error: NSError)
 }
 
 // MARK: - NSErrorProperties

--- a/Sources/PromotedCore/Errors.swift
+++ b/Sources/PromotedCore/Errors.swift
@@ -1,0 +1,116 @@
+import Foundation
+import SwiftProtobuf
+
+// MARK: - ErrorHandler
+
+/** Notified when internal errors occur in Promoted logging. */
+@objc(PROErrorListener)
+public protocol ErrorListener {
+  /// Called once per error after call to Promoted logging finishes.
+  /// Internal errors are surfaced to clients as `NSError` (see
+  /// `ClientConfigError`).
+  @objc func metricsLoggerDidError(_ error: NSError)
+}
+
+// MARK: - NSErrorProperties
+protocol NSErrorProperties {
+  
+  var domain: String { get }
+  
+  var code: Int { get }
+  
+  var message: String? { get }
+}
+
+extension NSErrorProperties {
+
+  var promotedAIDomain: String { "ai.promoted" }
+
+  func asNSError() -> NSError {
+    var userInfo: [String: Any]? = nil
+    if let message = self.message {
+      userInfo = ["message": message]
+    }
+    return NSError(domain: self.domain, code: self.code, userInfo: userInfo)
+  }
+}
+
+// MARK: - ClientConfigError
+/** Errors produced by `ClientConfig` on invalid settings. */
+public enum ClientConfigError: Error {
+
+  /// Invalid URL string was provided prior to network send.
+  case invalidURL(urlString: String)
+
+  /// `ClientConfig` is missing the API key.
+  case missingAPIKey
+
+  /// `ClientConfig` specified a `devMetricsLoggingURL` but did not
+  /// provide `devMetricsLoggingAPIKey`.
+  case missingDevAPIKey
+}
+
+extension ClientConfigError: NSErrorProperties {
+  var domain: String { promotedAIDomain }
+
+  var code: Int {
+    switch self {
+    case .invalidURL(_):
+      return 101
+    case .missingAPIKey:
+      return 102
+    case .missingDevAPIKey:
+      return 103
+    }
+  }
+
+  var message: String? {
+    switch self {
+    case .invalidURL(let urlString):
+      return urlString
+    case .missingAPIKey, .missingDevAPIKey:
+      return nil
+    }
+  }
+}
+
+// MARK: - ModuleConfigError
+/** Errors produced by `Module` on invalid `ModuleConfig`. */
+public enum ModuleConfigError: Error {
+  /// No `NetworkConnection` was provided.
+  case missingNetworkConnection
+}
+
+extension ModuleConfigError: NSErrorProperties {
+  var domain: String { promotedAIDomain }
+
+  var code: Int {
+    switch self {
+    case .missingNetworkConnection:
+      return 201
+    }
+  }
+
+  var message: String? { nil }
+}
+
+// MARK: - BinaryEncodingError
+extension BinaryEncodingError: NSErrorProperties {
+  var domain: String { "com.google.protobuf" }
+
+  var code: Int {
+    switch self {
+    case .missingRequiredFields:
+      return 301
+    case .anyTranscodeFailure:
+      return 302
+    }
+  }
+
+  var message: String? { nil }
+}
+
+func NSErrorForUnspecifiedError(_ error: Error) -> NSError {
+  return NSError(domain: "ai.promoted", code: 500,
+                 userInfo: ["message": error.localizedDescription])
+}

--- a/Sources/PromotedCore/MetricsLogger.swift
+++ b/Sources/PromotedCore/MetricsLogger.swift
@@ -524,11 +524,6 @@ extension MetricsLogger: OperationMonitorListener {
   func executionDidEnd(context: OperationMonitor.Context) {
     needsViewStateCheck = false
   }
-  
-  func execution(context: OperationMonitor.Context, didError error: Error) {}
-
-  func execution(context: OperationMonitor.Context,
-                 didLog loggingActivity: OperationMonitor.LoggingActivity) {}
 }
 
 // MARK: - Testing

--- a/Sources/PromotedCore/MetricsLogger.swift
+++ b/Sources/PromotedCore/MetricsLogger.swift
@@ -483,10 +483,11 @@ public extension MetricsLogger {
       let request = logRequestMessage(events: eventsCopy)
       monitor.executionDidLog(.message(request))
       do {
-        try connection.sendMessage(request, clientConfig: config, monitor: monitor) {
+        let data = try connection.sendMessage(request, clientConfig: config) {
           [weak self] (data, error) in
           self?.handleFlushResponse(data: data, error: error)
         }
+        monitor.executionDidLog(.data(data))
       } catch {
         osLog?.error("flush: %{public}@", error.localizedDescription)
         monitor.executionDidError(error)

--- a/Sources/PromotedCore/MetricsLogger.swift
+++ b/Sources/PromotedCore/MetricsLogger.swift
@@ -98,7 +98,7 @@ public final class MetricsLogger: NSObject {
   let viewTracker: ViewTracker
   private var needsViewStateCheck: Bool
 
-  private unowned var monitor: OperationMonitor!
+  private unowned var monitor: OperationMonitor
   private let osLog: OSLog?
 
   private lazy var cachedDeviceMessage: Event_Device = deviceMessage()

--- a/Sources/PromotedCore/MetricsLogger.swift
+++ b/Sources/PromotedCore/MetricsLogger.swift
@@ -99,14 +99,13 @@ public final class MetricsLogger: NSObject {
   private var needsViewStateCheck: Bool
 
   private unowned var monitor: OperationMonitor!
-  private unowned let xray: Xray?
   private let osLog: OSLog?
 
   private lazy var cachedDeviceMessage: Event_Device = deviceMessage()
 
   typealias Deps = ClientConfigSource & ClockSource & NetworkConnectionSource &
                    DeviceInfoSource & IDMapSource & OperationMonitorSource &
-                   OSLogSource & PersistentStoreSource & ViewTrackerSource & XraySource
+                   OSLogSource & PersistentStoreSource & ViewTrackerSource
 
   init(deps: Deps) {
     self.clock = deps.clock
@@ -116,7 +115,6 @@ public final class MetricsLogger: NSObject {
     self.idMap = deps.idMap
     self.monitor = deps.operationMonitor
     self.store = deps.persistentStore
-    self.xray = deps.xray
     self.osLog = deps.osLog(category: "MetricsLogger")
 
     self.logMessages = []
@@ -417,7 +415,7 @@ public extension MetricsLogger {
       return
     }
     logMessages.append(message)
-    xray?.callDidLog(message: message)
+    monitor.executionDidLog(.protobuf(message: message))
     maybeSchedulePendingBatchLoggingFlush()
   }
   
@@ -479,31 +477,34 @@ public extension MetricsLogger {
     cancelPendingBatchLoggingFlush()
     guard !logMessages.isEmpty else { return }
 
-    xray?.metricsLoggerBatchWillStart()
-    defer { xray?.metricsLoggerBatchDidComplete() }
-
-    let eventsCopy = logMessages
-    logMessages.removeAll()
-    let request = logRequestMessage(events: eventsCopy)
-    xray?.metricsLoggerBatchWillSend(message: request)
-    do {
-      try connection.sendMessage(request, clientConfig: config, xray: xray) {
-        [weak self] (data, error) in
-        self?.handleFlushResponse(data: data, error: error)
+    monitor.execute(context: .batch) {
+      let eventsCopy = logMessages
+      logMessages.removeAll()
+      let request = logRequestMessage(events: eventsCopy)
+      monitor.executionDidLog(.protobuf(message: request))
+      do {
+        try connection.sendMessage(request, clientConfig: config, monitor: monitor) {
+          [weak self] (data, error) in
+          self?.handleFlushResponse(data: data, error: error)
+        }
+      } catch {
+        osLog?.error("flush: %{public}@", error.localizedDescription)
+        monitor.executionDidError(error)
       }
-    } catch {
-      osLog?.error("flush: %{public}@", error.localizedDescription)
-      xray?.metricsLoggerBatchDidError(error)
     }
   }
   
   private func handleFlushResponse(data: Data?, error: Error?) {
-    osLog?.info("Logging finished")
-    if let e = error {
-      osLog?.error("flush/sendMessage: %{public}@", e.localizedDescription)
-      xray?.metricsLoggerBatchResponseDidError(e)
+    monitor.execute(context: .batchResponse) {
+      osLog?.info("Logging finished")
+      if let d = data {
+        monitor.executionDidLog(.bytes(data: d))
+      }
+      if let e = error {
+        osLog?.error("flush/sendMessage: %{public}@", e.localizedDescription)
+        monitor.executionDidError(e)
+      }
     }
-    xray?.metricsLoggerBatchResponseDidComplete()
   }
 }
 
@@ -516,13 +517,18 @@ extension MetricsLogger: OperationMonitorListener {
   /// on the first access of the `viewID` property. When called
   /// re-entrantly, only the first (outermost) call causes this
   /// view state check, since that check is relatively expensive.
-  func executionWillStart(context: String) {
+  func executionWillStart(context: OperationMonitor.Context) {
     needsViewStateCheck = true
   }
 
-  func executionDidEnd(context: String) {
+  func executionDidEnd(context: OperationMonitor.Context) {
     needsViewStateCheck = false
   }
+  
+  func execution(context: OperationMonitor.Context, didError error: Error) {}
+
+  func execution(context: OperationMonitor.Context,
+                 didLog loggingActivity: OperationMonitor.LoggingActivity) {}
 }
 
 // MARK: - Testing

--- a/Sources/PromotedCore/MetricsLogger.swift
+++ b/Sources/PromotedCore/MetricsLogger.swift
@@ -415,7 +415,7 @@ public extension MetricsLogger {
       return
     }
     logMessages.append(message)
-    monitor.executionDidLog(.protobuf(message: message))
+    monitor.executionDidLog(.message(message))
     maybeSchedulePendingBatchLoggingFlush()
   }
   
@@ -481,7 +481,7 @@ public extension MetricsLogger {
       let eventsCopy = logMessages
       logMessages.removeAll()
       let request = logRequestMessage(events: eventsCopy)
-      monitor.executionDidLog(.protobuf(message: request))
+      monitor.executionDidLog(.message(request))
       do {
         try connection.sendMessage(request, clientConfig: config, monitor: monitor) {
           [weak self] (data, error) in
@@ -498,7 +498,7 @@ public extension MetricsLogger {
     monitor.execute(context: .batchResponse) {
       osLog?.info("Logging finished")
       if let d = data {
-        monitor.executionDidLog(.bytes(data: d))
+        monitor.executionDidLog(.data(d))
       }
       if let e = error {
         osLog?.error("flush/sendMessage: %{public}@", e.localizedDescription)

--- a/Sources/PromotedCore/MetricsLoggerService.swift
+++ b/Sources/PromotedCore/MetricsLoggerService.swift
@@ -60,39 +60,73 @@ import os.log
 public final class MetricsLoggerService: NSObject {
 
   @objc public private(set) lazy var metricsLogger: MetricsLogger? = {
-    guard config.loggingEnabled else { return nil }
+    guard case .success = startupResult, config.loggingEnabled else {
+      return nil
+    }
     return MetricsLogger(deps: module)
   } ()
 
   @objc public var config: ClientConfig { module.clientConfig }
-  
+
   @objc public var xray: Xray? { module.xray }
 
   private let module: Module
+
+  public enum StartupResult {
+    case pending
+    case success
+    case failure(error: Error)
+  }
+  public private(set) var startupResult: StartupResult
 
   /// Creates a new service with a core configuration.
   /// This does not provide a `NetworkConnection`. If you are not
   /// supplying your own `NetworkConnection`, you should use
   /// `init(initialConfig:)` from the `PromotedMetrics` dependency.
-  @objc public init(coreInitialConfig: ClientConfig) {
-    self.module = Module(initialConfig: coreInitialConfig)
+  @objc public convenience init(coreInitialConfig: ClientConfig) {
+    let moduleConfig = ModuleConfig.coreConfig()
+    moduleConfig.initialConfig = coreInitialConfig
+    self.init(moduleConfig: moduleConfig)
   }
 
   @objc public init(moduleConfig: ModuleConfig) {
     self.module = Module(moduleConfig: moduleConfig)
+    self.startupResult = .pending
   }
+}
 
+// MARK: - Startup
+public extension MetricsLoggerService {
   /// Call this to start logging services, prior to accessing `logger`.
   /// Initialization is asynchronous, so this can be called from app
   /// startup without performance penalty. For example, in
   /// `application(_:didFinishLaunchingWithOptions:)`.
-  @objc public func startLoggingServices() {
-    module.verifyModuleConfigDependencies()
-    module.clientConfigService.fetchClientConfig()
+  ///
+  /// If this method throws an error, then the service becomes a no-op
+  /// object that returns `nil` for `metricsLogger`, `impressionLogger()`,
+  /// and `scrollTracker()`.
+  @objc func startLoggingServices() throws {
+    guard case .pending = startupResult else { return }
+    do {
+      try module.initialConfig.validateConfig()
+      try module.validateModuleConfigDependencies()
+      module.clientConfigService.fetchClientConfig()
+      startupResult = .success
+    } catch {
+      startupResult = .failure(error: error)
+      if let nsError = error as? NSErrorProperties {
+        throw nsError.asNSError()
+      }
+      throw error
+    }
   }
+}
+
+// MARK: - Impression logging
+public extension MetricsLoggerService {
 
   /// Returns a new `ImpressionLogger`.
-  @objc public func impressionLogger() -> ImpressionLogger? {
+  @objc func impressionLogger() -> ImpressionLogger? {
     guard let metricsLogger = self.metricsLogger else { return nil }
     return ImpressionLogger(metricsLogger: metricsLogger, deps: module)
   }
@@ -102,10 +136,7 @@ public final class MetricsLoggerService: NSObject {
     guard let metricsLogger = self.metricsLogger else { return nil }
     return ScrollTracker(metricsLogger: metricsLogger, deps: module)
   }
-}
 
-// MARK: - UIKit support
-public extension MetricsLoggerService {
   /// Returns a new `ScrollTracker` tied to the given `UIScrollView`.
   /// The scroll view must contain a `UICollectionView` to track, and
   /// clients must provide the `ScrollTracker` with the `UICollectionView`
@@ -138,22 +169,23 @@ public extension MetricsLoggerService {
   ///
   /// Equivalent to calling `init`, then `startLoggingServices()` on
   /// the shared service.
-  @objc static func startServices(coreInitialConfig: ClientConfig) {
+  @objc static func startServices(coreInitialConfig: ClientConfig) throws {
     let moduleConfig = ModuleConfig.coreConfig()
     moduleConfig.initialConfig = coreInitialConfig
-    startServices(moduleConfig: moduleConfig)
+    try startServices(moduleConfig: moduleConfig)
   }
 
   /// Call this to start logging services, prior to accessing `sharedService`.
   ///
   /// Equivalent to calling `init`, then `startLoggingServices()` on
   /// the shared service.
-  @objc static func startServices(moduleConfig: ModuleConfig) {
+  @objc static func startServices(moduleConfig: ModuleConfig) throws {
     self.moduleConfig = moduleConfig
-    self.shared.startLoggingServices()
+    try self.shared.startLoggingServices()
   }
 
-  /// Returns the shared logger. Causes error if `startServices` was not called.
+  /// Returns the shared logger. Causes runtime error if `startServices`
+  /// was not called.
   @objc(sharedService)
   static let shared: MetricsLoggerService = {
     assert(moduleConfig != nil, "Call startServices() before accessing shared service")

--- a/Sources/PromotedCore/MetricsLoggerService.swift
+++ b/Sources/PromotedCore/MetricsLoggerService.swift
@@ -67,12 +67,12 @@ import os.log
  ~~~objc
  NSError *error = nil;
  PROMetricsLoggerService *service =
-   [[PROMetricsLoggerService alloc] initWithInitialConfig:config error:&error];
+     [[PROMetricsLoggerService alloc]
+         initWithInitialConfig:config error:&error];
  if (error != nil) {
    LogInitializationError(error);
    return nil;
  }
- error = nil;
  [service startLoggingServicesAndReturnError:&error];
  if (error != nil) {
    LogInitializationError(error);
@@ -84,7 +84,8 @@ import os.log
  ## Example (Objective C ignoring errors):
  ~~~objc
  PROMetricsLoggerService *service =
-   [[PROMetricsLoggerService alloc] initWithInitialConfig:config error:nil];
+     [[PROMetricsLoggerService alloc]
+         initWithInitialConfig:config error:nil];
  [service startLoggingServicesAndReturnError:nil];
  return service;
  ~~~
@@ -156,7 +157,7 @@ public extension MetricsLoggerService {
   @objc func startLoggingServices() throws {
     guard case .pending = startupResult else { return }
     do {
-      try module.clientConfigService.fetchClientConfig()
+      try module.startLoggingServices()
       startupResult = .success
     } catch {
       startupResult = .failure(error: error)

--- a/Sources/PromotedCore/Module.swift
+++ b/Sources/PromotedCore/Module.swift
@@ -224,9 +224,6 @@ final class Module: AllDeps {
 
   /// Starts any services among dependencies.
   func startLoggingServices() throws {
-    if let xray = xray {
-      operationMonitor.addOperationMonitorListener(xray)
-    }
     try clientConfigService.fetchClientConfig()
   }
 }

--- a/Sources/PromotedCore/Module.swift
+++ b/Sources/PromotedCore/Module.swift
@@ -208,7 +208,7 @@ final class Module: AllDeps {
        clientConfigService: ClientConfigService? = nil,
        networkConnection: NetworkConnection? = nil,
        persistentStore: PersistentStore? = nil) {
-    self.initialConfig = initialConfig
+    self.initialConfig = initialConfig.copy()
     self.clientConfigServiceSpec = clientConfigService
     self.networkConnectionSpec = networkConnection
     self.persistentStoreSpec = persistentStore

--- a/Sources/PromotedCore/Module.swift
+++ b/Sources/PromotedCore/Module.swift
@@ -208,7 +208,7 @@ final class Module: AllDeps {
        clientConfigService: ClientConfigService? = nil,
        networkConnection: NetworkConnection? = nil,
        persistentStore: PersistentStore? = nil) {
-    self.initialConfig = initialConfig.copy()
+    self.initialConfig = ClientConfig(initialConfig)
     self.clientConfigServiceSpec = clientConfigService
     self.networkConnectionSpec = networkConnection
     self.persistentStoreSpec = persistentStore

--- a/Sources/PromotedCore/Module.swift
+++ b/Sources/PromotedCore/Module.swift
@@ -221,4 +221,12 @@ final class Module: AllDeps {
       throw ModuleConfigError.missingNetworkConnection
     }
   }
+
+  /// Starts any services among dependencies.
+  func startLoggingServices() throws {
+    if let xray = xray {
+      operationMonitor.addOperationMonitorListener(xray)
+    }
+    try clientConfigService.fetchClientConfig()
+  }
 }

--- a/Sources/PromotedCore/Module.swift
+++ b/Sources/PromotedCore/Module.swift
@@ -216,9 +216,9 @@ final class Module: AllDeps {
 
   /// Loads all dependencies from `ModuleConfig`. Ensures that any
   /// runtime errors occur early on in initialization.
-  func verifyModuleConfigDependencies() {
-    _ = clientConfigService
-    _ = networkConnection
-    _ = persistentStore
+  func validateModuleConfigDependencies() throws {
+    if networkConnectionSpec == nil {
+      throw ModuleConfigError.missingNetworkConnection
+    }
   }
 }

--- a/Sources/PromotedCore/NetworkConnection.swift
+++ b/Sources/PromotedCore/NetworkConnection.swift
@@ -17,7 +17,7 @@ public protocol NetworkConnection: AnyObject {
   ///     `metricsLoggingWireFormat` property of `clientConfig`, may
   ///     be serialized as JSON or binary format.
   ///   - clientConfig: Configuration to use to send message.
-  ///   - xray: Xray instance to analyze network traffic.
+  ///   - monitor: Records any sent data or errors.
   ///   - callback: Invoked on completion of the network op.
   ///     `NetworkConnection`s should manage their own retry logic, so
   ///     if `callback` is invoked with an error, that error indicates
@@ -28,7 +28,7 @@ public protocol NetworkConnection: AnyObject {
   ///   are passed through `callback`.
   func sendMessage(_ message: Message,
                    clientConfig: ClientConfig,
-                   xray: Xray?,
+                   monitor: OperationMonitor,
                    callback: Callback?) throws
 }
 
@@ -86,12 +86,6 @@ public extension NetworkConnection {
     }
     return request
   }
-
-  /// Records the data that will be sent over network, for the purpose
-  /// of client introspection via `Xray`. Optional.
-  func recordBytesToSend(_ data: Data, xray: Xray?) {
-    xray?.metricsLoggerBatchWillSend(data: data)
-  }
 }
 
 // MARK: - NoOpNetworkConnection
@@ -99,6 +93,6 @@ public extension NetworkConnection {
 final class NoOpNetworkConnection: NetworkConnection {
   func sendMessage(_ message: Message,
                    clientConfig: ClientConfig,
-                   xray: Xray?,
+                   monitor: OperationMonitor,
                    callback: Callback?) throws {}
 }

--- a/Sources/PromotedCore/NetworkConnection.swift
+++ b/Sources/PromotedCore/NetworkConnection.swift
@@ -4,7 +4,7 @@ import SwiftProtobuf
 // MARK: -
 /** Network connection used to send log messages to server. */
 public protocol NetworkConnection: AnyObject {
-  
+
   /// Callback for `sendMessage`. Will be invoked on main thread.
   typealias Callback = (Data?, Error?) -> Void
 
@@ -22,7 +22,7 @@ public protocol NetworkConnection: AnyObject {
   ///     `NetworkConnection`s should manage their own retry logic, so
   ///     if `callback` is invoked with an error, that error indicates
   ///     a failure *after* retrying. Clients should not retry further.
-  /// - Throws: `NetworkConnectionError.messageSerializationError` for
+  /// - Throws: `ClientConfigError.messageSerializationError` for
   ///   any errors that occurred in protobuf serialization *prior to*
   ///   the network operation. Errors resulting from the network operation
   ///   are passed through `callback`.
@@ -38,6 +38,9 @@ protocol NetworkConnectionSource {
 
 // MARK: -
 public extension NetworkConnection {
+  /// Returns the URL to use for logging endpoint.
+  /// Optional convenience method.
+  /// Implementations should propagate `ClientConfigError`s.
   func metricsLoggingURL(clientConfig: ClientConfig) throws -> URL {
     #if DEBUG
     let urlString = clientConfig.devMetricsLoggingURL
@@ -46,11 +49,14 @@ public extension NetworkConnection {
     #endif
 
     guard let url = URL(string: urlString) else {
-      throw NetworkConnectionError.invalidURLError(urlString: urlString)
+      throw ClientConfigError.invalidURL(urlString: urlString)
     }
     return url
   }
-  
+
+  /// Returns binary data to send over the network request.
+  /// Optional convenience method.
+  /// Implementations should propagate `ClientConfigError`s.
   func bodyData(message: Message, clientConfig: ClientConfig) throws -> Data {
     switch clientConfig.metricsLoggingWireFormat {
     case .binary:
@@ -60,7 +66,10 @@ public extension NetworkConnection {
     }
   }
 
-  func urlRequest(url: URL, data: Data, clientConfig: ClientConfig) -> URLRequest {
+  /// Creates a `URLRequest` for use with the given request. Will set
+  /// the API key on the resulting request. Optional convenience method.
+  /// Implementations should propagate `ClientConfigError`s.
+  func urlRequest(url: URL, data: Data, clientConfig: ClientConfig) throws -> URLRequest {
     var request = URLRequest(url: url)
     #if DEBUG
     let apiKey = clientConfig.devMetricsLoggingAPIKey
@@ -68,6 +77,9 @@ public extension NetworkConnection {
     let apiKey = clientConfig.metricsLoggingAPIKey
     #endif
 
+    guard !apiKey.isEmpty else {
+      throw ClientConfigError.missingAPIKey
+    }
     request.addValue(apiKey, forHTTPHeaderField: "x-api-key")
     if clientConfig.metricsLoggingWireFormat == .binary {
       request.addValue("application/protobuf", forHTTPHeaderField: "content-type")
@@ -75,6 +87,8 @@ public extension NetworkConnection {
     return request
   }
 
+  /// Records the data that will be sent over network, for the purpose
+  /// of client introspection via `Xray`. Optional.
   func recordBytesToSend(_ data: Data, xray: Xray?) {
     xray?.metricsLoggerBatchWillSend(data: data)
   }
@@ -87,21 +101,4 @@ final class NoOpNetworkConnection: NetworkConnection {
                    clientConfig: ClientConfig,
                    xray: Xray?,
                    callback: Callback?) throws {}
-}
-
-// MARK: - NetworkConnectionError
-/** Class of errors produced by `NetworkConnection`. */
-public enum NetworkConnectionError: Error {
-  
-  /// Indicates an error in message serialization prior to network send.
-  case messageSerializationError(message: String)
-  
-  /// Indicates an error from the network operation after completion.
-  case networkSendError(domain: String, code: Int, errorString: String)
-  
-  /// Indicates an invalid URL string was provided.
-  case invalidURLError(urlString: String)
-  
-  /// Indicates an error that is not one of the above cases.
-  case unknownError
 }

--- a/Sources/PromotedCore/NetworkConnection.swift
+++ b/Sources/PromotedCore/NetworkConnection.swift
@@ -17,19 +17,16 @@ public protocol NetworkConnection: AnyObject {
   ///     `metricsLoggingWireFormat` property of `clientConfig`, may
   ///     be serialized as JSON or binary format.
   ///   - clientConfig: Configuration to use to send message.
-  ///   - monitor: Records any sent data or errors.
   ///   - callback: Invoked on completion of the network op.
   ///     `NetworkConnection`s should manage their own retry logic, so
   ///     if `callback` is invoked with an error, that error indicates
   ///     a failure *after* retrying. Clients should not retry further.
-  /// - Throws: `ClientConfigError.messageSerializationError` for
-  ///   any errors that occurred in protobuf serialization *prior to*
-  ///   the network operation. Errors resulting from the network operation
-  ///   are passed through `callback`.
+  /// - Returns: Data sent over network connection.
+  /// - Throws: Propagate any errors thrown by underlying network
+  //    connection or by the methods in `NetworkConnection` extension.
   func sendMessage(_ message: Message,
                    clientConfig: ClientConfig,
-                   monitor: OperationMonitor,
-                   callback: Callback?) throws
+                   callback: Callback?) throws -> Data
 }
 
 protocol NetworkConnectionSource {
@@ -93,6 +90,5 @@ public extension NetworkConnection {
 final class NoOpNetworkConnection: NetworkConnection {
   func sendMessage(_ message: Message,
                    clientConfig: ClientConfig,
-                   monitor: OperationMonitor,
-                   callback: Callback?) throws {}
+                   callback: Callback?) throws -> Data { Data() }
 }

--- a/Sources/PromotedCore/OperationMonitor.swift
+++ b/Sources/PromotedCore/OperationMonitor.swift
@@ -36,21 +36,21 @@ extension OperationMonitorListener {
  state for a series of grouped logging operations, performance
  monitoring, and respecting state of kill switch.
  */
-public final class OperationMonitor {
+final class OperationMonitor {
 
-  public enum Context {
+  enum Context {
     case clientInitiated(function: String)
     case batch
     case batchResponse
   }
-  fileprivate typealias Stack = [Context]
 
-  public enum LoggingActivity {
+  enum LoggingActivity {
     case message(_ message: Message)
     case data(_ data: Data)
   }
 
-  public typealias Operation = () -> Void
+  typealias Operation = () -> Void
+  fileprivate typealias Stack = [Context]
 
   private var listeners: WeakArray<OperationMonitorListener>
   private var contextStack: Stack
@@ -109,13 +109,13 @@ public final class OperationMonitor {
   }
 
   /// Call when library operation produces an error.
-  public func executionDidError(_ error: Error) {
+  func executionDidError(_ error: Error) {
     guard let context = contextStack.bottom else { return }
     listeners.forEach { $0.execution(context: context, didError: error) }
   }
 
   /// Call when library operation logs a message.
-  public func executionDidLog(_ loggingActivity: LoggingActivity) {
+  func executionDidLog(_ loggingActivity: LoggingActivity) {
     guard let context = contextStack.bottom else { return }
     listeners.forEach { $0.execution(context: context, willLog: loggingActivity) }
   }

--- a/Sources/PromotedCore/OperationMonitor.swift
+++ b/Sources/PromotedCore/OperationMonitor.swift
@@ -12,10 +12,22 @@ protocol OperationMonitorListener: AnyObject {
   /// Called when an error is reported.
   func execution(context: OperationMonitor.Context, didError error: Error)
 
-  /// Called when
+  /// Called when a log message is sent.
   func execution(context: OperationMonitor.Context,
                  didLog loggingActivity: OperationMonitor.LoggingActivity)
 }
+
+extension OperationMonitorListener {
+  func executionWillStart(context: OperationMonitor.Context) {}
+
+  func executionDidEnd(context: OperationMonitor.Context) {}
+
+  func execution(context: OperationMonitor.Context, didError error: Error) {}
+
+  func execution(context: OperationMonitor.Context,
+                 didLog loggingActivity: OperationMonitor.LoggingActivity) {}
+}
+
 
 /**
  Wraps all public, client-facing operations. Provides context and

--- a/Sources/PromotedCore/OperationMonitor.swift
+++ b/Sources/PromotedCore/OperationMonitor.swift
@@ -39,7 +39,7 @@ extension OperationMonitorListener {
 final class OperationMonitor {
 
   enum Context {
-    case clientInitiated(function: String)
+    case function(_ function: String)
     case batch
     case batchResponse
   }
@@ -86,14 +86,14 @@ final class OperationMonitor {
   ///   - context: Identifier for execution context for Xray
   ///   - function: Function from which call was made
   ///   - operation: Block to execute if logging enabled
-  func execute(context: Context = .clientInitiated(function: ""),
+  func execute(context: Context = .function(""),
                function: String = #function,
                operation: Operation) {
     var executionContext = context
     // Fill in function here because the #function macro doesn't
     // work from inside the enum.
-    if case .clientInitiated(_) = context {
-      executionContext = .clientInitiated(function: function)
+    if case .function(_) = context {
+      executionContext = .function(function)
     }
     if contextStack.isEmpty {
       listeners.forEach { $0.executionWillStart(context: executionContext) }
@@ -144,7 +144,7 @@ fileprivate extension OperationMonitor.Stack {
 extension OperationMonitor.Context: CustomDebugStringConvertible {
   public var debugDescription: String {
     switch self {
-    case .clientInitiated(let function):
+    case .function(let function):
       return function
     default:
       return String(describing: self)

--- a/Sources/PromotedCore/OperationMonitor.swift
+++ b/Sources/PromotedCore/OperationMonitor.swift
@@ -1,12 +1,20 @@
 import Foundation
+import SwiftProtobuf
 
 /** Listens for execution scopes. */
 protocol OperationMonitorListener: AnyObject {
   /// Called when the outermost `execute()` starts.
-  func executionWillStart(context: String)
+  func executionWillStart(context: OperationMonitor.Context)
 
   /// Called when the outermost `execute()` ends.
-  func executionDidEnd(context: String)
+  func executionDidEnd(context: OperationMonitor.Context)
+
+  /// Called when an error is reported.
+  func execution(context: OperationMonitor.Context, didError error: Error)
+
+  /// Called when
+  func execution(context: OperationMonitor.Context,
+                 didLog loggingActivity: OperationMonitor.LoggingActivity)
 }
 
 /**
@@ -15,16 +23,28 @@ protocol OperationMonitorListener: AnyObject {
  state for a series of grouped logging operations, performance
  monitoring, and respecting state of kill switch.
  */
-final class OperationMonitor {
+public final class OperationMonitor {
 
-  typealias Operation = () -> Void
+  public enum Context {
+    case clientInitiated(function: String)
+    case batch
+    case batchResponse
+  }
+  fileprivate typealias Stack = [Context]
+
+  public enum LoggingActivity {
+    case protobuf(message: Message)
+    case bytes(data: Data)
+  }
+
+  public typealias Operation = () -> Void
 
   private var listeners: WeakArray<OperationMonitorListener>
-  private var exectionDepth: Int
-  
+  private var contextStack: Stack
+
   init() {
     self.listeners = []
-    self.exectionDepth = 0
+    self.contextStack = []
   }
   
   func addOperationMonitorListener(_ listener: OperationMonitorListener) {
@@ -51,22 +71,57 @@ final class OperationMonitor {
   ///
   /// - Parameters:
   ///   - context: Identifier for execution context for Xray
+  ///   - function: Function from which call was made
   ///   - operation: Block to execute if logging enabled
-  func execute(context: String = #function, operation: Operation) {
-    if exectionDepth == 0 {
-      listeners.forEach { $0.executionWillStart(context: context) }
+  func execute(context: Context = .clientInitiated(function: ""),
+               function: String = #function,
+               operation: Operation) {
+    var executionContext = context
+    // Fill in function here because the #function macro doesn't
+    // work from inside the enum call.
+    if case .clientInitiated(_) = context {
+      executionContext = .clientInitiated(function: function)
     }
-    exectionDepth += 1
+    if contextStack.isEmpty {
+      listeners.forEach { $0.executionWillStart(context: executionContext) }
+    }
+    contextStack.push(executionContext)
     defer {
-      exectionDepth -= 1
-      if exectionDepth == 0 {
-        listeners.forEach { $0.executionDidEnd(context: context) }
+      contextStack.pop()
+      if contextStack.isEmpty {
+        listeners.forEach { $0.executionDidEnd(context: executionContext) }
       }
     }
     operation()
+  }
+
+  /// Call when library operation produces an error.
+  public func executionDidError(_ error: Error) {
+    guard let context = contextStack.bottom else { return }
+    listeners.forEach { $0.execution(context: context, didError: error) }
+  }
+
+  /// Call when library operation logs a message.
+  public func executionDidLog(_ loggingActivity: LoggingActivity) {
+    guard let context = contextStack.bottom else { return }
+    listeners.forEach { $0.execution(context: context, didLog: loggingActivity) }
   }
 }
 
 protocol OperationMonitorSource {
   var operationMonitor: OperationMonitor { get }
+}
+
+fileprivate extension OperationMonitor.Stack {
+
+  var top: OperationMonitor.Context? { last }
+  var bottom: OperationMonitor.Context? { first }
+
+  mutating func push(_ context: OperationMonitor.Context) {
+    append(context)
+  }
+
+  @discardableResult mutating func pop() -> OperationMonitor.Context {
+    return removeLast()
+  }
 }

--- a/Sources/PromotedCore/ViewTracker.swift
+++ b/Sources/PromotedCore/ViewTracker.swift
@@ -126,7 +126,7 @@ extension ViewTracker.State: CustomDebugStringConvertible {
 
 // MARK: - Stack
 fileprivate extension ViewTracker.Stack {
-  var top: ViewTracker.State? { return last }
+  var top: ViewTracker.State? { last }
   
   mutating func push(_ entry: ViewTracker.State) {
     append(entry)

--- a/Sources/PromotedCore/Xray.swift
+++ b/Sources/PromotedCore/Xray.swift
@@ -326,7 +326,7 @@ fileprivate extension Xray {
 extension Xray: OperationMonitorListener {
   func executionWillStart(context: OperationMonitor.Context) {
     switch context {
-    case .clientInitiated(let function):
+    case .function(let function):
       callWillStart(context: function)
     case .batch:
       metricsLoggerBatchWillStart()
@@ -337,7 +337,7 @@ extension Xray: OperationMonitorListener {
 
   func executionDidEnd(context: OperationMonitor.Context) {
     switch context {
-    case .clientInitiated(_):
+    case .function(_):
       callDidComplete()
     case .batch:
       metricsLoggerBatchDidComplete()
@@ -348,7 +348,7 @@ extension Xray: OperationMonitorListener {
 
   func execution(context: OperationMonitor.Context, didError error: Error) {
     switch context {
-    case .clientInitiated(_):
+    case .function(_):
       callDidError(error)
     case .batch:
       metricsLoggerBatchDidError(error)
@@ -360,7 +360,7 @@ extension Xray: OperationMonitorListener {
   func execution(context: OperationMonitor.Context,
                  willLog loggingActivity: OperationMonitor.LoggingActivity) {
     switch context {
-    case .clientInitiated(_):
+    case .function(_):
       if case let .message(message) = loggingActivity {
         callDidLog(message: message)
       }

--- a/Sources/PromotedCore/Xray.swift
+++ b/Sources/PromotedCore/Xray.swift
@@ -155,7 +155,8 @@ public final class Xray: NSObject {
   private let callStacksEnabled: Bool
   private let osLog: OSLog?
 
-  typealias Deps = ClockSource & ClientConfigSource & OperationMonitorSource & OSLogSource
+  typealias Deps = ClockSource & ClientConfigSource &
+      OperationMonitorSource & OSLogSource
 
   init(deps: Deps) {
     self.clock = deps.clock
@@ -169,7 +170,7 @@ public final class Xray: NSObject {
     self.networkBatches = []
     self.pendingCalls = []
     self.pendingBatch = nil
-
+    
     super.init()
     deps.operationMonitor.addOperationMonitorListener(self)
   }

--- a/Sources/PromotedCoreTestHelpers/FakeNetworkConnection.swift
+++ b/Sources/PromotedCoreTestHelpers/FakeNetworkConnection.swift
@@ -18,8 +18,8 @@ final class FakeNetworkConnection: NetworkConnection {
   
   func sendMessage(_ message: Message,
                    clientConfig: ClientConfig,
-                   monitor: OperationMonitor,
-                   callback: Callback?) throws {
+                   callback: Callback?) throws -> Data {
     messages.append(SendMessageArguments(message: message, callback: callback))
+    return try message.serializedData()
   }
 }

--- a/Sources/PromotedCoreTestHelpers/FakeNetworkConnection.swift
+++ b/Sources/PromotedCoreTestHelpers/FakeNetworkConnection.swift
@@ -18,7 +18,7 @@ final class FakeNetworkConnection: NetworkConnection {
   
   func sendMessage(_ message: Message,
                    clientConfig: ClientConfig,
-                   xray: Xray?,
+                   monitor: OperationMonitor,
                    callback: Callback?) throws {
     messages.append(SendMessageArguments(message: message, callback: callback))
   }

--- a/Sources/PromotedFetcher/GTMSessionFetcherConnection.swift
+++ b/Sources/PromotedFetcher/GTMSessionFetcherConnection.swift
@@ -22,12 +22,12 @@ final class GTMSessionFetcherConnection: NetworkConnection {
 
   func sendMessage(_ message: Message,
                    clientConfig: ClientConfig,
-                   xray: Xray?,
+                   monitor: OperationMonitor,
                    callback: Callback?) throws {
     let url = try metricsLoggingURL(clientConfig: clientConfig)
     let data = try bodyData(message: message, clientConfig: clientConfig)
     let request = try urlRequest(url: url, data: data, clientConfig: clientConfig)
-    recordBytesToSend(data, xray: xray)
+    monitor.executionDidLog(.bytes(data: data))
     let fetcher = fetcherService.fetcher(with: request)
     fetcher.isRetryEnabled = true
     fetcher.bodyData = data

--- a/Sources/PromotedFetcher/GTMSessionFetcherConnection.swift
+++ b/Sources/PromotedFetcher/GTMSessionFetcherConnection.swift
@@ -27,7 +27,7 @@ final class GTMSessionFetcherConnection: NetworkConnection {
     let url = try metricsLoggingURL(clientConfig: clientConfig)
     let data = try bodyData(message: message, clientConfig: clientConfig)
     let request = try urlRequest(url: url, data: data, clientConfig: clientConfig)
-    monitor.executionDidLog(.bytes(data: data))
+    monitor.executionDidLog(.data(data))
     let fetcher = fetcherService.fetcher(with: request)
     fetcher.isRetryEnabled = true
     fetcher.bodyData = data

--- a/Sources/PromotedFetcher/GTMSessionFetcherConnection.swift
+++ b/Sources/PromotedFetcher/GTMSessionFetcherConnection.swift
@@ -24,32 +24,13 @@ final class GTMSessionFetcherConnection: NetworkConnection {
                    clientConfig: ClientConfig,
                    xray: Xray?,
                    callback: Callback?) throws {
-    do {
-      let url = try metricsLoggingURL(clientConfig: clientConfig)
-      let data = try bodyData(message: message, clientConfig: clientConfig)
-      let request = urlRequest(url: url, data: data, clientConfig: clientConfig)
-      recordBytesToSend(data, xray: xray)
-      let fetcher = fetcherService.fetcher(with: request)
-      fetcher.isRetryEnabled = true
-      fetcher.bodyData = data
-      fetcher.beginFetch { (data, error) in
-        var callbackError = error
-        if let e = error as NSError? {
-          var errorString = ""
-          if let data = e.userInfo["data"] as? Data {
-            errorString = String(decoding: data, as: UTF8.self)
-          }
-          callbackError = NetworkConnectionError.networkSendError(
-              domain: e.domain, code: e.code, errorString: errorString)
-        }
-        callback?(data, callbackError)
-      }
-    } catch BinaryEncodingError.missingRequiredFields {
-      throw NetworkConnectionError.messageSerializationError(message: "Missing required fields.")
-    } catch BinaryEncodingError.anyTranscodeFailure {
-      throw NetworkConnectionError.messageSerializationError(message: "`Any` transcode failed.")
-    } catch {
-      throw NetworkConnectionError.unknownError
-    }
+    let url = try metricsLoggingURL(clientConfig: clientConfig)
+    let data = try bodyData(message: message, clientConfig: clientConfig)
+    let request = try urlRequest(url: url, data: data, clientConfig: clientConfig)
+    recordBytesToSend(data, xray: xray)
+    let fetcher = fetcherService.fetcher(with: request)
+    fetcher.isRetryEnabled = true
+    fetcher.bodyData = data
+    fetcher.beginFetch { (data, error) in callback?(data, error) }
   }
 }

--- a/Sources/PromotedFetcher/GTMSessionFetcherConnection.swift
+++ b/Sources/PromotedFetcher/GTMSessionFetcherConnection.swift
@@ -22,15 +22,14 @@ final class GTMSessionFetcherConnection: NetworkConnection {
 
   func sendMessage(_ message: Message,
                    clientConfig: ClientConfig,
-                   monitor: OperationMonitor,
-                   callback: Callback?) throws {
+                   callback: Callback?) throws -> Data {
     let url = try metricsLoggingURL(clientConfig: clientConfig)
     let data = try bodyData(message: message, clientConfig: clientConfig)
     let request = try urlRequest(url: url, data: data, clientConfig: clientConfig)
-    monitor.executionDidLog(.data(data))
     let fetcher = fetcherService.fetcher(with: request)
     fetcher.isRetryEnabled = true
     fetcher.bodyData = data
     fetcher.beginFetch { (data, error) in callback?(data, error) }
+    return data
   }
 }

--- a/Sources/PromotedMetrics/MetricsLoggerService+PromotedMetrics.swift
+++ b/Sources/PromotedMetrics/MetricsLoggerService+PromotedMetrics.swift
@@ -10,10 +10,10 @@ public extension MetricsLoggerService {
   ///
   /// Equivalent to calling `init`, then `startLoggingServices()` on
   /// the shared service.
-  @objc static func startServices(initialConfig: ClientConfig) {
+  @objc static func startServices(initialConfig: ClientConfig) throws {
     let moduleConfig = ModuleConfig.defaultConfig()
     moduleConfig.initialConfig = initialConfig
-    startServices(moduleConfig: moduleConfig)
+    try startServices(moduleConfig: moduleConfig)
   }
 
   /// Creates a new service with a core configuration.

--- a/Sources/PromotedMetrics/MetricsLoggerService+PromotedMetrics.swift
+++ b/Sources/PromotedMetrics/MetricsLoggerService+PromotedMetrics.swift
@@ -18,9 +18,9 @@ public extension MetricsLoggerService {
 
   /// Creates a new service with a core configuration.
   /// Creates a default implementation for `NetworkConnection`.
-  @objc convenience init(initialConfig: ClientConfig) {
+  @objc convenience init(initialConfig: ClientConfig) throws {
     let moduleConfig = ModuleConfig.defaultConfig()
     moduleConfig.initialConfig = initialConfig
-    self.init(moduleConfig: moduleConfig)
+    try self.init(moduleConfig: moduleConfig)
   }
 }

--- a/Tests/PromotedCoreTests/NetworkConnectionTests.swift
+++ b/Tests/PromotedCoreTests/NetworkConnectionTests.swift
@@ -17,7 +17,7 @@ final class NetworkConnectionTests: ModuleTestCase {
       let jsonString = String(data: jsonData, encoding: .utf8)!
       XCTAssertEqual("{\"actionId\":\"foo\"}", jsonString)
     } catch {
-      XCTFail("JSON serialization threw an exception.")
+      XCTFail("JSON serialization threw an error: \(error)")
     }
   }
   
@@ -30,7 +30,7 @@ final class NetworkConnectionTests: ModuleTestCase {
       let binaryData = try connection.bodyData(message: message, clientConfig: config)
       XCTAssertGreaterThan(binaryData.count, 0)
     } catch {
-      XCTFail("Binary serialization threw an exception.")
+      XCTFail("Binary serialization threw an error: \(error)")
     }
   }
     
@@ -39,7 +39,11 @@ final class NetworkConnectionTests: ModuleTestCase {
     config.metricsLoggingAPIKey = config.devMetricsLoggingAPIKey
     let url = URL(string: "http://promoted.ai")!
     let data = "foobar".data(using: .utf8)!
-    let request = connection.urlRequest(url: url, data: data, clientConfig: config)
-    XCTAssertEqual("key!", request.allHTTPHeaderFields!["x-api-key"]!)
+    do {
+      let request = try connection.urlRequest(url: url, data: data, clientConfig: config)
+      XCTAssertEqual("key!", request.allHTTPHeaderFields!["x-api-key"]!)
+    } catch {
+      XCTFail("URL request threw an error: \(error)")
+    }
   }
 }

--- a/Tests/PromotedCoreTests/OperationMonitorTests.swift
+++ b/Tests/PromotedCoreTests/OperationMonitorTests.swift
@@ -8,13 +8,29 @@ final class OperationMonitorTests: XCTestCase {
   class Listener: OperationMonitorListener {
     var starts: [String] = []
     var ends: [String] = []
+    var errors: [(String, Error)] = []
+    var activities: [(String, Data)] = []
 
-    func executionWillStart(context: String) {
-      starts.append(context)
+    func executionWillStart(context: OperationMonitor.Context) {
+      starts.append(context.debugDescription)
     }
-    
-    func executionDidEnd(context: String) {
-      ends.append(context)
+
+    func executionDidEnd(context: OperationMonitor.Context) {
+      ends.append(context.debugDescription)
+    }
+
+    func execution(context: OperationMonitor.Context, didError error: Error) {
+      errors.append((context.debugDescription, error))
+    }
+
+    func execution(context: OperationMonitor.Context,
+                   willLog loggingActivity: OperationMonitor.LoggingActivity) {
+      switch loggingActivity {
+      case .message(let message):
+        XCTFail("Unexpected call to log \(message)")
+      case .data(let data):
+        activities.append((context.debugDescription, data))
+      }
     }
   }
   
@@ -38,19 +54,41 @@ final class OperationMonitorTests: XCTestCase {
   }
   
   func testNestedExecute() {
-    monitor.execute(context: "outer") {
+    monitor.execute(function: "outer") {
       XCTAssertEqual(["outer"], listener.starts)
       XCTAssertEqual([], listener.ends)
-      monitor.execute(context: "inner1") {
+      monitor.execute(function: "inner1") {
         XCTAssertEqual(["outer"], listener.starts)
         XCTAssertEqual([], listener.ends)
       }
-      monitor.execute(context: "inner2") {
+      monitor.execute(function: "inner2") {
         XCTAssertEqual(["outer"], listener.starts)
         XCTAssertEqual([], listener.ends)
       }
     }
     XCTAssertEqual(["outer"], listener.starts)
     XCTAssertEqual(["outer"], listener.ends)
+  }
+  
+  func testLoggingActivityAndErrors() {
+    let error1 = NSError(domain: "ai.promoted", code: -1, userInfo: nil)
+    let error2 = NSError(domain: "ai.promoted", code: -2, userInfo: nil)
+    let data = "I am the very model of a modern hippopotamus".data(using: .utf8)!
+    monitor.execute(function: "outer") {
+      monitor.executionDidError(error1)
+      monitor.execute(function: "inner1") {
+        monitor.executionDidError(error2)
+      }
+      monitor.execute(function: "inner2") {
+        monitor.executionDidLog(.data(data))
+      }
+    }
+    let actualErrors = listener.errors
+    XCTAssertEqual(["outer", "outer"], actualErrors.map(\.0))
+    XCTAssertIdentical(error1, actualErrors[0].1 as AnyObject)
+    XCTAssertIdentical(error2, actualErrors[1].1 as AnyObject)
+    let actualLoggingActivities = listener.activities
+    XCTAssertEqual(["outer"], actualLoggingActivities.map(\.0))
+    XCTAssertEqual([data], actualLoggingActivities.map(\.1))
   }
 }

--- a/Tests/PromotedCoreTests/OperationMonitorTests.swift
+++ b/Tests/PromotedCoreTests/OperationMonitorTests.swift
@@ -85,8 +85,8 @@ final class OperationMonitorTests: XCTestCase {
     }
     let actualErrors = listener.errors
     XCTAssertEqual(["outer", "outer"], actualErrors.map(\.0))
-    XCTAssertIdentical(error1, actualErrors[0].1 as AnyObject)
-    XCTAssertIdentical(error2, actualErrors[1].1 as AnyObject)
+    XCTAssertEqual(error1, actualErrors[0].1 as NSError)
+    XCTAssertEqual(error2, actualErrors[1].1 as NSError)
     let actualLoggingActivities = listener.activities
     XCTAssertEqual(["outer"], actualLoggingActivities.map(\.0))
     XCTAssertEqual([data], actualLoggingActivities.map(\.1))

--- a/Tests/PromotedCoreTests/XrayTests.swift
+++ b/Tests/PromotedCoreTests/XrayTests.swift
@@ -17,7 +17,7 @@ final class XrayTests: ModuleTestCase {
   
   func testSingleBatch() {
     clock.advance(toMillis: 0)
-    let actionContext = Context.clientInitiated(function: "logAction")
+    let actionContext = Context.function("logAction")
     xray.executionWillStart(context: actionContext)
     var action = Event_Action()
     action.actionID = "fake-action-id"
@@ -26,7 +26,7 @@ final class XrayTests: ModuleTestCase {
     xray.executionDidEnd(context: actionContext)
     
     clock.advance(toMillis: 200)
-    let impressionContext = Context.clientInitiated(function: "logImpression")
+    let impressionContext = Context.function("logImpression")
     xray.executionWillStart(context: impressionContext)
     var impression = Event_Impression()
     impression.impressionID = "fake-impression-id"
@@ -83,7 +83,7 @@ final class XrayTests: ModuleTestCase {
   func testCalls() {
 
     func callXray(_ function: String) -> Context {
-      let context = Context.clientInitiated(function: function)
+      let context = Context.function(function)
       xray.executionWillStart(context: context)
       xray.executionDidEnd(context: context)
       return context
@@ -123,7 +123,7 @@ final class XrayTests: ModuleTestCase {
       xray.executionDidEnd(context: .batchResponse)
     }
 
-    let context1 = Context.clientInitiated(function: "f1")
+    let context1 = Context.function("f1")
     let error1 = NSError(domain: "ai.promoted", code: -1, userInfo: nil)
     xray.executionWillStart(context: context1)
     xray.execution(context: context1, didError: error1)
@@ -131,7 +131,7 @@ final class XrayTests: ModuleTestCase {
 
     batchXray()
 
-    let context2 = Context.clientInitiated(function: "f2")
+    let context2 = Context.function("f2")
     let error2 = NSError(domain: "ai.promoted", code: -2, userInfo: nil)
     xray.executionWillStart(context: context2)
     xray.execution(context: context2, didError: error2)
@@ -140,7 +140,7 @@ final class XrayTests: ModuleTestCase {
     let error3 = NSError(domain: "ai.promoted", code: -3, userInfo: nil)
     batchXray(batchError: error3)
 
-    let context3 = Context.clientInitiated(function: "f3")
+    let context3 = Context.function("f3")
     xray.executionWillStart(context: context3)
     xray.executionDidEnd(context: context3)
 

--- a/Tests/PromotedCoreTests/XrayTests.swift
+++ b/Tests/PromotedCoreTests/XrayTests.swift
@@ -8,6 +8,8 @@ final class XrayTests: ModuleTestCase {
   
   private var xray: Xray!
   
+  typealias Context = OperationMonitor.Context
+  
   override func setUp() {
     super.setUp()
     xray = Xray(deps: module)
@@ -15,32 +17,35 @@ final class XrayTests: ModuleTestCase {
   
   func testSingleBatch() {
     clock.advance(toMillis: 0)
-    xray.callWillStart(context: "logAction")
+    let actionContext = Context.clientInitiated(function: "logAction")
+    xray.executionWillStart(context: actionContext)
     var action = Event_Action()
     action.actionID = "fake-action-id"
-    xray.callDidLog(message: action)
+    xray.execution(context: actionContext, willLog: .message(action))
     clock.advance(toMillis: 123)
-    xray.callDidComplete()
+    xray.executionDidEnd(context: actionContext)
     
     clock.advance(toMillis: 200)
-    xray.callWillStart(context: "logImpression")
+    let impressionContext = Context.clientInitiated(function: "logImpression")
+    xray.executionWillStart(context: impressionContext)
     var impression = Event_Impression()
     impression.impressionID = "fake-impression-id"
-    xray.callDidLog(message: impression)
+    xray.execution(context: impressionContext, willLog: .message(impression))
     clock.advance(toMillis: 250)
-    xray.callDidComplete()
+    xray.executionDidEnd(context: impressionContext)
     
     clock.advance(toMillis: 456)
-    xray.metricsLoggerBatchWillStart()
+    xray.executionWillStart(context: .batch)
     var logRequest = Event_LogRequest()
     logRequest.action.append(action)
-    xray.metricsLoggerBatchWillSend(message: logRequest)
+    xray.execution(context: .batch, willLog: .message(logRequest))
     let data = "fake http body".data(using: .utf8)!
-    xray.metricsLoggerBatchWillSend(data: data)
+    xray.execution(context: .batch, willLog: .data(data))
     clock.advance(toMillis: 789)
-    xray.metricsLoggerBatchDidComplete()
+    xray.executionDidEnd(context: .batch)
     clock.advance(toMillis: 1234)
-    xray.metricsLoggerBatchResponseDidComplete()
+    xray.executionWillStart(context: .batchResponse)
+    xray.executionDidEnd(context: .batchResponse)
 
     let networkTime: TimeIntervalMillis = 1234
     let batchTime: TimeIntervalMillis = 789 - 456
@@ -75,5 +80,74 @@ final class XrayTests: ModuleTestCase {
     XCTAssertEqual(impression, call2.messages[0] as! Event_Impression)
   }
   
-  // TODO(yu-hong): More tests.
+  func testCalls() {
+
+    func callXray(_ function: String) -> Context {
+      let context = Context.clientInitiated(function: function)
+      xray.executionWillStart(context: context)
+      xray.executionDidEnd(context: context)
+      return context
+    }
+
+    func batchXray(_ functions: [String]) -> [Context] {
+      let allCalls = functions.map { callXray($0) }
+      xray.executionWillStart(context: .batch)
+      xray.executionDidEnd(context: .batch)
+      xray.executionWillStart(context: .batchResponse)
+      xray.executionDidEnd(context: .batchResponse)
+      return allCalls
+    }
+
+    var allCalls = [Context]()
+    allCalls.append(contentsOf: batchXray(["hello", "world"]))
+    allCalls.append(contentsOf: batchXray(["hello", "darkness"]))
+    allCalls.append(contentsOf: batchXray(["my", "old", "friend"]))
+
+    XCTAssertEqual(allCalls.map(\.debugDescription),
+                   xray.calls.map(\.context))
+  }
+  
+  func testErrors() {
+    
+    func batchXray(batchError: Error? = nil,
+                   batchResponseError: Error? = nil) {
+      xray.executionWillStart(context: .batch)
+      if let e = batchError {
+        xray.execution(context: .batch, didError: e)
+      }
+      xray.executionDidEnd(context: .batch)
+      xray.executionWillStart(context: .batchResponse)
+      if let e = batchResponseError {
+        xray.execution(context: .batchResponse, didError: e)
+      }
+      xray.executionDidEnd(context: .batchResponse)
+    }
+
+    let context1 = Context.clientInitiated(function: "f1")
+    let error1 = NSError(domain: "ai.promoted", code: -1, userInfo: nil)
+    xray.executionWillStart(context: context1)
+    xray.execution(context: context1, didError: error1)
+    xray.executionDidEnd(context: context1)
+
+    batchXray()
+
+    let context2 = Context.clientInitiated(function: "f2")
+    let error2 = NSError(domain: "ai.promoted", code: -2, userInfo: nil)
+    xray.executionWillStart(context: context2)
+    xray.execution(context: context2, didError: error2)
+    xray.executionDidEnd(context: context2)
+
+    let error3 = NSError(domain: "ai.promoted", code: -3, userInfo: nil)
+    batchXray(batchError: error3)
+
+    let context3 = Context.clientInitiated(function: "f3")
+    xray.executionWillStart(context: context3)
+    xray.executionDidEnd(context: context3)
+
+    let error4 = NSError(domain: "ai.promoted", code: -4, userInfo: nil)
+    batchXray(batchResponseError: error4)
+
+    let expected = [error1, error2, error3, error4]
+    XCTAssertEqual(expected, xray.errors as [NSError])
+  }
 }


### PR DESCRIPTION
- Create a common defined set of errors to surface to clients.
  - Errors with definition of `ClientConfig` or `ModuleConfig` are surfaced to clients at `MetricsLoggerService` initialization.
  - Errors that occur at runtime (proto serialization, networking errors) are propagated to error handlers as-is.
- Use `OperationManager` as a layer of indirection for log message/error reporting.
  - Refactor `Xray` and `MetricsLogger` to use this indirection.
- Add tests for `OperationManager` and `Xray`.