### PR TITLE
Fall back to metrics URL/API key if dev versions aren't set

### DIFF
--- a/Sources/PromotedCore/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig.swift
@@ -39,6 +39,10 @@ public final class ClientConfig: NSObject {
   /// URL for logging endpoint as used by `NetworkConnection`
   /// for debug/staging purposes. Used when the app is running
   /// in debug configuration.
+  ///
+  /// If this property is not set, then debug builds will use
+  /// `metricsLoggingURL` for logging endpoint URL.
+  ///
   /// Implementations of `NetworkConnection` from Promoted will
   /// use this field. Custom implementations of `NetworkConnection`
   /// may vary in behavior.
@@ -52,6 +56,13 @@ public final class ClientConfig: NSObject {
   
   /// API key for logging endpoint for debug/staging purposes.
   /// Used when the app is running in debug configuration.
+  ///
+  /// If this property is not set, then debug builds will use
+  /// `metricsLoggingAPIKey` for logging endpoint API key.
+  ///
+  /// Implementations of `NetworkConnection` from Promoted will
+  /// use this field. Custom implementations of `NetworkConnection`
+  /// may vary in behavior.
   @objc public var devMetricsLoggingAPIKey: String = ""
 
   /// HTTP header field for API key.

--- a/Sources/PromotedCore/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig.swift
@@ -54,6 +54,9 @@ public final class ClientConfig: NSObject {
   /// Used when the app is running in debug configuration.
   @objc public var devMetricsLoggingAPIKey: String = ""
 
+  /// HTTP header field for API key.
+  @objc public var apiKeyHTTPHeaderField: String = "x-api-key"
+
   /// Format to use when sending protobuf log messages over network.
   public enum MetricsLoggingWireFormat: Int {
     /// https://developers.google.com/protocol-buffers/docs/proto3#json

--- a/Sources/PromotedCore/NetworkConnection.swift
+++ b/Sources/PromotedCore/NetworkConnection.swift
@@ -39,10 +39,11 @@ public extension NetworkConnection {
   /// Optional convenience method.
   /// Implementations should propagate `ClientConfigError`s.
   func metricsLoggingURL(clientConfig: ClientConfig) throws -> URL {
+    var urlString = clientConfig.metricsLoggingURL
     #if DEBUG
-    let urlString = clientConfig.devMetricsLoggingURL
-    #else
-    let urlString = clientConfig.metricsLoggingURL
+    if !clientConfig.devMetricsLoggingURL.isEmpty {
+      urlString = clientConfig.devMetricsLoggingURL
+    }
     #endif
 
     guard let url = URL(string: urlString) else {
@@ -68,16 +69,18 @@ public extension NetworkConnection {
   /// Implementations should propagate `ClientConfigError`s.
   func urlRequest(url: URL, data: Data, clientConfig: ClientConfig) throws -> URLRequest {
     var request = URLRequest(url: url)
+    var apiKey = clientConfig.metricsLoggingAPIKey
     #if DEBUG
-    let apiKey = clientConfig.devMetricsLoggingAPIKey
-    #else
-    let apiKey = clientConfig.metricsLoggingAPIKey
+    if !clientConfig.devMetricsLoggingAPIKey.isEmpty {
+      apiKey = clientConfig.devMetricsLoggingAPIKey
+    }
     #endif
 
     guard !apiKey.isEmpty else {
       throw ClientConfigError.missingAPIKey
     }
-    request.addValue(apiKey, forHTTPHeaderField: "x-api-key")
+    let field = clientConfig.apiKeyHTTPHeaderField
+    request.addValue(apiKey, forHTTPHeaderField: field)
     if clientConfig.metricsLoggingWireFormat == .binary {
       request.addValue("application/protobuf", forHTTPHeaderField: "content-type")
     }

--- a/Sources/PromotedCore/NetworkConnection.swift
+++ b/Sources/PromotedCore/NetworkConnection.swift
@@ -23,7 +23,7 @@ public protocol NetworkConnection: AnyObject {
   ///     a failure *after* retrying. Clients should not retry further.
   /// - Returns: Data sent over network connection.
   /// - Throws: Propagate any errors thrown by underlying network
-  //    connection or by the methods in `NetworkConnection` extension.
+  ///    connection or by the methods in `NetworkConnection` extension.
   func sendMessage(_ message: Message,
                    clientConfig: ClientConfig,
                    callback: Callback?) throws -> Data


### PR DESCRIPTION
This makes Hipcamp's setup more convenient.