### PR TITLE
Support `ImpressionSourceType`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ Your app controls the initialization and behavior of our client library through 
 
 1. `MetricsLoggingService` configures the behavior and initialization of the library. 
 1. `MetricsLogger` accepts log messages to send to the server. 
-1. `ImpressionLogger` tracks impressions of content in a collection view.
+1. `ImpressionTracker` tracks impressions of content in a collection view.
 
 ### MetricsLoggerService
 Initialization of the library is lightweight and mostly occurs in the background, and does not impact app startup performance.
 
 Example usage (singleton):
-~~~swift
+```swift
 // In your AppDelegate:
 func application(_ application: UIApplication,
                  didFinishLaunchingWithOptions...) -> Bool {
@@ -62,10 +62,10 @@ func application(_ application: UIApplication,
   self.logger = loggingService.metricsLogger
   return true
 }
-~~~
+```
 
 Example usage (dependency injection):
-~~~swift
+```swift
 // In your AppDelegate:
 func application(_ application: UIApplication,
                  didFinishLaunchingWithOptions...) -> Bool {
@@ -77,10 +77,10 @@ func application(_ application: UIApplication,
   self.logger = service.metricsLogger
   return true
 }
-~~~
+```
 
 Handling user sign-in:
-~~~swift
+```swift
 // Handling user sign-in/sign-out:
 func userDidSignInWithID(_ userID: String) {
   self.logger.startSessionAndLogUser(userID: userID);
@@ -89,36 +89,36 @@ func userDidSignInWithID(_ userID: String) {
 func userDidSignOut() {
   self.logger.startSessionAndLogSignedOutUser()
 }
-~~~
+```
 
 ### MetricsLogger
 `MetricsLogger` batches log messages to avoid wasteful network traffic that would affect battery life. It also provides hooks into the app’s life cycle to ensure delivery of client logs.
 
-### ImpressionLogger
-For `UICollectionViews` and other scroll views, we can track the appearance and disappearance of individual cells for fine-grained impression logging. We provide `ImpressionLogger`, a solution that hooks into most `UICollectionView`s and `UIViewController`s easily.
+### ImpressionTracker
+For `UICollectionViews` and other scroll views, we can track the appearance and disappearance of individual cells for fine-grained impression logging. We provide `ImpressionTracker`, a solution that hooks into most `UICollectionView`s and `UIViewController`s easily.
 
 Example usage with UICollectionView:
-~~~swift
+```swift
 class MyViewController: UIViewController {
   var collectionView: UICollectionView
-  var impressionLogger: ImpressionLogger
+  var impressionTracker: ImpressionTracker
 
   func viewWillDisappear(_ animated: Bool) {
-    impressionLogger.collectionViewDidHideAllContent()
+    impressionTracker.collectionViewDidHideAllContent()
   }
 
   func collectionView(_ collectionView: UICollectionView,
                       willDisplay cell: UICollectionViewCell,
                       forItemAt indexPath: IndexPath) {
     let content = contentFor(indexPath: indexPath)
-    impressionLogger.collectionViewWillDisplay(content: content)
+    impressionTracker.collectionViewWillDisplay(content: content)
   }
    
   func collectionView(_ collectionView: UICollectionView,
                       didEndDisplaying cell: UICollectionViewCell,
                       forItemAt indexPath: IndexPath) {
     let content = contentFor(indexPath: indexPath)
-    impressionLogger.collectionViewDidHide(content: content)
+    impressionTracker.collectionViewDidHide(content: content)
   }
 
   func reloadCollectionView() {
@@ -126,7 +126,7 @@ class MyViewController: UIViewController {
     let visibleContent = collectionView.indexPathsForVisibleItems.map {
       contentFor(indexPath: $0)
     }
-    impressionLogger.collectionViewDidChangeVisibleContent(visibleContent)
+    impressionTracker.collectionViewDidChangeVisibleContent(visibleContent)
   }
 }
-~~~
+```

--- a/Sources/PromotedCore/Impression/ImpressionConfig.swift
+++ b/Sources/PromotedCore/Impression/ImpressionConfig.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/**
+ Configuration for impression logging contexts.
+ Methods contained herein modify and return `self`.
+ */
+@objc(PROImpressionConfig)
+public protocol ImpressionConfig {
+
+  /// Configures the impression logging context to use a
+  /// given source type for all logged impressions.
+  @objc(withSourceType:)
+  @discardableResult
+  func with(sourceType: ImpressionSourceType) -> Self
+}

--- a/Sources/PromotedCore/Impression/ImpressionTracker.swift
+++ b/Sources/PromotedCore/Impression/ImpressionTracker.swift
@@ -213,8 +213,8 @@ public extension ImpressionTracker {
 // MARK: - Impression CustomDebugStringConvertible
 extension ImpressionTracker.Impression: CustomDebugStringConvertible {
   public var debugDescription: String {
-    endTime != nil ? "(\(content.description), \(startTime), \(endTime!))"
-      : "(\(content.description), \(startTime))"
+    endTime != nil ? "(\(content.description), \(startTime), \(endTime!), \(sourceType))"
+      : "(\(content.description), \(startTime), \(sourceType))"
   }
 }
 
@@ -222,12 +222,14 @@ extension ImpressionTracker.Impression: CustomDebugStringConvertible {
 extension ImpressionTracker.Impression: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(content)
+    hasher.combine(sourceType)
   }
   
   public static func == (lhs: ImpressionTracker.Impression,
                          rhs: ImpressionTracker.Impression) -> Bool {
     ((lhs.content == rhs.content) &&
      (abs(lhs.startTime - rhs.startTime) < 0.01) &&
-     (abs((lhs.endTime ?? 0) - (rhs.endTime ?? 0)) < 0.01))
+     (abs((lhs.endTime ?? 0) - (rhs.endTime ?? 0)) < 0.01) &&
+     (lhs.sourceType == rhs.sourceType))
   }
 }

--- a/Sources/PromotedCore/Impression/ScrollTracker.swift
+++ b/Sources/PromotedCore/Impression/ScrollTracker.swift
@@ -82,7 +82,7 @@ import UIKit
  view updates.
  */
 @objc(PROScrollTracker)
-public final class ScrollTracker: NSObject {
+public final class ScrollTracker: NSObject, ImpressionConfig {
 
   private let visibilityThreshold: Float
   private let durationThreshold: TimeInterval
@@ -267,6 +267,15 @@ public extension ScrollTracker {
     let origin = scrollView.convert(scrollView.contentOffset, to: collectionView);
     let size = scrollView.frame.size
     viewport = CGRect(origin: origin, size: size)
+  }
+}
+
+// MARK: - ImpressionConfig
+public extension ScrollTracker {
+  @discardableResult
+  func with(sourceType: ImpressionSourceType) -> Self {
+    impressionTracker.with(sourceType: sourceType)
+    return self
   }
 }
 

--- a/Sources/PromotedCore/ImpressionTracker.swift
+++ b/Sources/PromotedCore/ImpressionTracker.swift
@@ -2,17 +2,17 @@ import Foundation
 
 // MARK: -
 /** Delegate to be notified when impressions start or end. */
-public protocol ImpressionLoggerDelegate: AnyObject {
+public protocol ImpressionTrackerDelegate: AnyObject {
 
   /// Notifies delegate of impression starts.
-  func impressionLogger(
-      _ impressionLogger: ImpressionLogger,
-      didStartImpressions impressions: [ImpressionLogger.Impression])
+  func impressionTracker(
+      _ impressionTracker: ImpressionTracker,
+      didStartImpressions impressions: [ImpressionTracker.Impression])
   
   /// Notifies delegate of impression ends.
-  func impressionLogger(
-      _ impressionLogger: ImpressionLogger,
-      didEndImpressions impressions: [ImpressionLogger.Impression])
+  func impressionTracker(
+      _ impressionTracker: ImpressionTracker,
+      didEndImpressions impressions: [ImpressionTracker.Impression])
 }
 
 // MARK: -
@@ -23,7 +23,7 @@ public protocol ImpressionLoggerDelegate: AnyObject {
  adapted to work with views that don't.
 
  ## Usage
- `ImpressionLogger` provides only basic impression tracking logic that
+ `ImpressionTracker` provides only basic impression tracking logic that
  considers a view as impressed as soon as it enters the screen. For
  more advanced functionality, see `ScrollTracker`, which offers
  visibility and time threshholds.
@@ -31,16 +31,16 @@ public protocol ImpressionLoggerDelegate: AnyObject {
  Used from React Native because RN's `SectionList` and `FlatList`
  provide this advanced functionality already.
 
- Clients should create an instance of `ImpressionLogger`
+ Clients should create an instance of `ImpressionTracker`
  and reference it in their view controller, then provide updates
  to the impression logger as the collection view scrolls or updates.
  
  # Example:
- ~~~
+ ```swift
  class MyViewController: UIViewController {
    var collectionView: UICollectionView
    var logger: MetricsLogger
-   var impressionLogger: ImpressionLogger
+   var impressionTracker: ImpressionTracker
  
    private func content(atIndexPath path: IndexPath) -> Content? {
      let item = path.item
@@ -50,14 +50,14 @@ public protocol ImpressionLoggerDelegate: AnyObject {
    }
 
    func viewWillDisappear(_ animated: Bool) {
-     impressionLogger.collectionViewDidHideAllContent()
+     impressionTracker.collectionViewDidHideAllContent()
    }
 
    func collectionView(_ collectionView: UICollectionView,
                        willDisplay cell: UICollectionViewCell,
                        forItemAt indexPath: IndexPath) {
      if let content = content(atIndexPath: indexPath) {
-      impressionLogger.collectionViewWillDisplay(content: content)
+      impressionTracker.collectionViewWillDisplay(content: content)
      }
    }
     
@@ -65,7 +65,7 @@ public protocol ImpressionLoggerDelegate: AnyObject {
                        didEndDisplaying cell: UICollectionViewCell,
                        forItemAt indexPath: IndexPath) {
      if let content = content(atIndexPath: indexPath) {
-       impressionLogger.collectionViewDidHide(content: content)
+       impressionTracker.collectionViewDidHide(content: content)
      }
    }
 
@@ -74,13 +74,13 @@ public protocol ImpressionLoggerDelegate: AnyObject {
      let visibleContent = collectionView.indexPathsForVisibleItems.map {
        path in content(atIndexPath: path)
      };
-     impressionLogger.collectionViewDidChangeVisibleContent(visibleContent)
+     impressionTracker.collectionViewDidChangeVisibleContent(visibleContent)
    }
  }
- ~~~
+ ```
  */
-@objc(PROImpressionLogger)
-public final class ImpressionLogger: NSObject {
+@objc(PROImpressionTracker)
+public final class ImpressionTracker: NSObject {
 
   // MARK: -
   /** Represents an impression of a cell in the collection view. */
@@ -109,7 +109,7 @@ public final class ImpressionLogger: NSObject {
   
   private var impressionStarts: [Content: TimeInterval]
 
-  public weak var delegate: ImpressionLoggerDelegate?
+  public weak var delegate: ImpressionTrackerDelegate?
 
   typealias Deps = ClockSource & OperationMonitorSource
 
@@ -175,7 +175,7 @@ public final class ImpressionLogger: NSObject {
         metricsLogger.logImpression(content: impression.content)
       }
     }
-    delegate?.impressionLogger(self, didStartImpressions: impressions)
+    delegate?.impressionTracker(self, didStartImpressions: impressions)
   }
   
   private func broadcastEndAndRemoveImpressions<T: Collection>(
@@ -188,24 +188,24 @@ public final class ImpressionLogger: NSObject {
       impressions.append(impression)
     }
     // Not calling `metricsLogger`. No logging end impressions for now.
-    delegate?.impressionLogger(self, didEndImpressions: impressions)
+    delegate?.impressionTracker(self, didEndImpressions: impressions)
   }
 }
 
-extension ImpressionLogger.Impression: CustomDebugStringConvertible {
+extension ImpressionTracker.Impression: CustomDebugStringConvertible {
   public var debugDescription: String {
     endTime != nil ? "(\(content.description), \(startTime), \(endTime!))"
       : "(\(content.description), \(startTime))"
   }
 }
 
-extension ImpressionLogger.Impression: Hashable {
+extension ImpressionTracker.Impression: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(content)
   }
   
-  public static func == (lhs: ImpressionLogger.Impression,
-                         rhs: ImpressionLogger.Impression) -> Bool {
+  public static func == (lhs: ImpressionTracker.Impression,
+                         rhs: ImpressionTracker.Impression) -> Bool {
     ((lhs.content == rhs.content) &&
      (abs(lhs.startTime - rhs.startTime) < 0.01) &&
      (abs((lhs.endTime ?? 0) - (rhs.endTime ?? 0)) < 0.01))

--- a/Sources/PromotedCore/MetricsLogger+Helpers.swift
+++ b/Sources/PromotedCore/MetricsLogger+Helpers.swift
@@ -1,14 +1,24 @@
 import Foundation
 import UIKit
 
+// MARK: - Impression logging helper methods
 public extension MetricsLogger {
-  // MARK: - Impression logging helper methods
   /// Logs an impression for the given content.
   @objc func logImpression(content: Content) {
-    logImpression(contentID: content.contentID, insertionID: content.insertionID)
+    logImpression(content: content, sourceType: .unknown)
   }
 
-  // MARK: - Action logging helper methods
+  /// Logs an impression for the given content and source type.
+  @objc func logImpression(content: Content,
+                           sourceType: ImpressionSourceType) {
+    logImpression(contentID: content.contentID,
+                  insertionID: content.insertionID,
+                  sourceType: sourceType)
+  }
+}
+
+// MARK: - Action logging helper methods
+public extension MetricsLogger {
   /// Logs a navigate action to the given view controller.
   @objc func logNavigateAction(viewController: UIViewController) {
     logNavigateAction(name: viewController.promotedViewLoggingName,
@@ -167,8 +177,10 @@ public extension MetricsLogger {
               contentID: content.contentID,
               insertionID: content.insertionID)
   }
+}
 
-  // MARK: - View logging helper methods
+// MARK: - View logging helper methods
+public extension MetricsLogger {
   /// Logs a view of the given `UIViewController`.
   @objc func logView(viewController: UIViewController) {
     logView(trackerKey: .uiKit(viewController: viewController))

--- a/Sources/PromotedCore/MetricsLogger.swift
+++ b/Sources/PromotedCore/MetricsLogger.swift
@@ -36,14 +36,14 @@ import os.log
  Use from main thread only.
 
  ## Example:
- ~~~
+ ```swift
  let logger = MetricsLogger(...)
  // Sets userID and logUserID for subsequent log() calls.
  logger.startSession(userID: myUserID)
  logger.log(event: myEvent)
  // Resets userID and logUserID.
  logger.startSession(userID: secondUserID)
- ~~~
+ ```
  */
 @objc(PROMetricsLogger)
 public final class MetricsLogger: NSObject {
@@ -310,10 +310,13 @@ public extension MetricsLogger {
   /// - Parameters:
   ///   - contentID: Content ID from which to derive `impressionID`
   ///   - insertionID: Insertion ID as provided by Promoted
+  ///   - requestID: Request ID as provided by Promoted
+  ///   - sourceType: Origin of the impressed content
   ///   - properties: Client-specific message
   func logImpression(contentID: String? = nil,
                      insertionID: String? = nil,
                      requestID: String? = nil,
+                     sourceType: ImpressionSourceType? = nil,
                      properties: Message? = nil) {
     monitor.execute {
       var impression = Event_Impression()
@@ -324,6 +327,7 @@ public extension MetricsLogger {
       if let id = sessionID { impression.sessionID = id }
       if let id = viewID { impression.viewID = id }
       if let id = contentID { impression.contentID = idMap.contentID(clientID: id) }
+      if let t = sourceType?.protoValue { impression.sourceType = t }
       if let p = propertiesMessage(properties) { impression.properties = p }
       log(message: impression)
     }
@@ -345,6 +349,7 @@ public extension MetricsLogger {
   ///   - name: Name for action to log, human readable
   ///   - contentID: Content ID from which to derive `impressionID`
   ///   - insertionID: Insertion ID as provided by Promoted
+  ///   - requestID: Request ID as provided by Promoted
   ///   - properties: Client-specific message
   func logAction(name: String,
                  type: ActionType,

--- a/Sources/PromotedCore/MetricsLoggerService.swift
+++ b/Sources/PromotedCore/MetricsLoggerService.swift
@@ -10,13 +10,13 @@ import os.log
  `MetricsLoggingService`, which configures the logging environment and
  maintains a `MetricsLogger` for the lifetime of the service. 
  
- The service also provides a facility to create `ImpressionLogger`s and
+ The service also provides a facility to create `ImpressionTracker`s and
  `ScrollTracker`s.
  
  # Usage
  Create and configure the service when your app starts, then retrieve the
  `MetricsLogger` instance from the service after it has been configured.
- Alternatively, create `ImpressionLogger` instances using the service.
+ Alternatively, create `ImpressionTracker` instances using the service.
 
  You may choose to make `MetricsLoggerService` a singleton, which makes its
  corresponding `MetricsLogger` a singleton. You may also choose to
@@ -31,22 +31,22 @@ import os.log
  Use from main thread only.
  
  ## Example (using instance):
- ~~~swift
+ ```swift
  let service = try MetricsLoggerService(initialConfig: ...)
  try service.startLoggingServices()
  let logger = service.metricsLogger
- let impressionLogger = service.impressionLogger()
+ let impressionTracker = service.impressionTracker()
  let scrollTracker = service.scrollTracker(collectionView: ...)
- ~~~
+ ```
  
  ## Example (using shared service):
- ~~~swift
+ ```swift
  // Call this first before accessing the instance.
  try MetricsLoggerService.startServices(initialConfig: ...)
  let service = MetricsLoggerService.shared
  let logger = service.metricsLogger
- let impressionLogger = service.impressionLogger()
- ~~~
+ let impressionTracker = service.impressionTracker()
+ ```
  
  # PromotedCore vs PromotedMetrics
  The above example uses the `PromotedMetrics` dependency. It's assumed
@@ -64,7 +64,7 @@ import os.log
  Initialization errors may not be logged to analytics.
  
  ## Example (Objective C full error handling):
- ~~~objc
+```objc
  NSError *error = nil;
  PROMetricsLoggerService *service =
      [[PROMetricsLoggerService alloc]
@@ -79,16 +79,16 @@ import os.log
    return nil;
  }
  return service;
- ~~~
+```
  
  ## Example (Objective C ignoring errors):
- ~~~objc
+ ```objc
  PROMetricsLoggerService *service =
      [[PROMetricsLoggerService alloc]
          initWithInitialConfig:config error:nil];
  [service startLoggingServicesAndReturnError:nil];
  return service;
- ~~~
+ ```
  */
 @objc(PROMetricsLoggerService)
 public final class MetricsLoggerService: NSObject {
@@ -148,7 +148,7 @@ public extension MetricsLoggerService {
   ///
   /// If this method fails or throws an error, then the service becomes
   /// a no-op object that returns `nil` for `metricsLogger`,
-  /// `impressionLogger()`, and `scrollTracker()`. In Swift, it's safe
+  /// `impressionTracker()`, and `scrollTracker()`. In Swift, it's safe
   /// to ignore the thrown error, with `try? service.startLoggingServices()`.
   /// In Objective C, it's safe to ignore the failure/error from
   /// `[service startLoggingServicesAndReturnError:]`.
@@ -169,10 +169,10 @@ public extension MetricsLoggerService {
 // MARK: - Impression logging
 public extension MetricsLoggerService {
 
-  /// Returns a new `ImpressionLogger`.
-  @objc func impressionLogger() -> ImpressionLogger? {
+  /// Returns a new `ImpressionTracker`.
+  @objc func impressionTracker() -> ImpressionTracker? {
     guard let metricsLogger = self.metricsLogger else { return nil }
-    return ImpressionLogger(metricsLogger: metricsLogger, deps: module)
+    return ImpressionTracker(metricsLogger: metricsLogger, deps: module)
   }
 
   /// Returns a new `ScrollTracker`.

--- a/Sources/PromotedCore/Model/ImpressionSourceType.swift
+++ b/Sources/PromotedCore/Model/ImpressionSourceType.swift
@@ -16,6 +16,7 @@ public enum ImpressionSourceType: Int {
     case 0: self = .unknown
     case 1: self = .delivery
     case 2: self = .clientBackend
+    default: self = .unknown
     }
   }
 

--- a/Sources/PromotedCore/Model/ImpressionSourceType.swift
+++ b/Sources/PromotedCore/Model/ImpressionSourceType.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/** Type for origin of impressed content. */
+@objc(PROImpressionSourceType)
+public enum ImpressionSourceType: Int {
+  case unknown = 0
+
+  /// Promoted Delivery API.
+  case delivery = 1
+
+  /// Non-Promoted backend.
+  case clientBackend = 2
+
+  public init?(rawValue: Int) {
+    switch rawValue {
+    case 0: self = .unknown
+    case 1: self = .delivery
+    case 2: self = .clientBackend
+    }
+  }
+
+  var protoValue: Event_ImpressionSourceType? {
+    Event_ImpressionSourceType(rawValue: self.rawValue)
+  }
+}

--- a/Sources/PromotedCore/SchemaProtos/proto_common_common.pb.swift
+++ b/Sources/PromotedCore/SchemaProtos/proto_common_common.pb.swift
@@ -182,6 +182,117 @@ public struct Common_UserInfo {
   public init() {}
 }
 
+/// Info about the client.
+/// Next ID = 3.
+public struct Common_ClientInfo {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var clientType: Common_ClientInfo.ClientType = .unknownRequestClient
+
+  public var trafficType: Common_ClientInfo.TrafficType = .unknownTrafficType
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  /// Next ID = 5;
+  public enum ClientType: SwiftProtobuf.Enum {
+    public typealias RawValue = Int
+    case unknownRequestClient // = 0
+
+    /// Your (customer) server.
+    case platformServer // = 1
+
+    /// Your (customer) client.
+    case platformClient // = 2
+    case UNRECOGNIZED(Int)
+
+    public init() {
+      self = .unknownRequestClient
+    }
+
+    public init?(rawValue: Int) {
+      switch rawValue {
+      case 0: self = .unknownRequestClient
+      case 1: self = .platformServer
+      case 2: self = .platformClient
+      default: self = .UNRECOGNIZED(rawValue)
+      }
+    }
+
+    public var rawValue: Int {
+      switch self {
+      case .unknownRequestClient: return 0
+      case .platformServer: return 1
+      case .platformClient: return 2
+      case .UNRECOGNIZED(let i): return i
+      }
+    }
+
+  }
+
+  /// Used to indicate the type of traffic.  We can use this to prioritize resources.
+  /// Next ID = 4.
+  public enum TrafficType: SwiftProtobuf.Enum {
+    public typealias RawValue = Int
+    case unknownTrafficType // = 0
+
+    /// Live traffic.
+    case production // = 1
+
+    /// Replayed traffic.  We'd like similar to PRODUCTION level.
+    case replay // = 2
+    case UNRECOGNIZED(Int)
+
+    public init() {
+      self = .unknownTrafficType
+    }
+
+    public init?(rawValue: Int) {
+      switch rawValue {
+      case 0: self = .unknownTrafficType
+      case 1: self = .production
+      case 2: self = .replay
+      default: self = .UNRECOGNIZED(rawValue)
+      }
+    }
+
+    public var rawValue: Int {
+      switch self {
+      case .unknownTrafficType: return 0
+      case .production: return 1
+      case .replay: return 2
+      case .UNRECOGNIZED(let i): return i
+      }
+    }
+
+  }
+
+  public init() {}
+}
+
+#if swift(>=4.2)
+
+extension Common_ClientInfo.ClientType: CaseIterable {
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  public static var allCases: [Common_ClientInfo.ClientType] = [
+    .unknownRequestClient,
+    .platformServer,
+    .platformClient,
+  ]
+}
+
+extension Common_ClientInfo.TrafficType: CaseIterable {
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  public static var allCases: [Common_ClientInfo.TrafficType] = [
+    .unknownTrafficType,
+    .production,
+    .replay,
+  ]
+}
+
+#endif  // swift(>=4.2)
+
 /// A message containing timing information.
 ///
 /// We can add common timing info to this message.  Down the road, we might
@@ -197,20 +308,13 @@ public struct Common_Timing {
   /// Optional.  Client timestamp when event was created.
   public var clientLogTimestamp: UInt64 = 0
 
-  /// Read-only.  This is set in the Event API.
-  public var eventApiTimestamp: UInt64 = 0
-
-  /// Internal to our metrics pipeline.  Currently set by kafka and used to
-  /// manage state for event joining.
-  public var logTimestamp: UInt64 = 0
-
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 }
 
 /// Supports custom properties per platform.
-/// Next ID = 3.
+/// Next ID = 4.
 public struct Common_Properties {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -397,12 +501,64 @@ extension Common_UserInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplemen
   }
 }
 
+extension Common_ClientInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ClientInfo"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "client_type"),
+    2: .standard(proto: "traffic_type"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularEnumField(value: &self.clientType) }()
+      case 2: try { try decoder.decodeSingularEnumField(value: &self.trafficType) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.clientType != .unknownRequestClient {
+      try visitor.visitSingularEnumField(value: self.clientType, fieldNumber: 1)
+    }
+    if self.trafficType != .unknownTrafficType {
+      try visitor.visitSingularEnumField(value: self.trafficType, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Common_ClientInfo, rhs: Common_ClientInfo) -> Bool {
+    if lhs.clientType != rhs.clientType {return false}
+    if lhs.trafficType != rhs.trafficType {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Common_ClientInfo.ClientType: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "UNKNOWN_REQUEST_CLIENT"),
+    1: .same(proto: "PLATFORM_SERVER"),
+    2: .same(proto: "PLATFORM_CLIENT"),
+  ]
+}
+
+extension Common_ClientInfo.TrafficType: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "UNKNOWN_TRAFFIC_TYPE"),
+    1: .same(proto: "PRODUCTION"),
+    2: .same(proto: "REPLAY"),
+  ]
+}
+
 extension Common_Timing: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Timing"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "client_log_timestamp"),
-    2: .standard(proto: "event_api_timestamp"),
-    3: .standard(proto: "log_timestamp"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -412,8 +568,6 @@ extension Common_Timing: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularUInt64Field(value: &self.clientLogTimestamp) }()
-      case 2: try { try decoder.decodeSingularUInt64Field(value: &self.eventApiTimestamp) }()
-      case 3: try { try decoder.decodeSingularUInt64Field(value: &self.logTimestamp) }()
       default: break
       }
     }
@@ -423,19 +577,11 @@ extension Common_Timing: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
     if self.clientLogTimestamp != 0 {
       try visitor.visitSingularUInt64Field(value: self.clientLogTimestamp, fieldNumber: 1)
     }
-    if self.eventApiTimestamp != 0 {
-      try visitor.visitSingularUInt64Field(value: self.eventApiTimestamp, fieldNumber: 2)
-    }
-    if self.logTimestamp != 0 {
-      try visitor.visitSingularUInt64Field(value: self.logTimestamp, fieldNumber: 3)
-    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Common_Timing, rhs: Common_Timing) -> Bool {
     if lhs.clientLogTimestamp != rhs.clientLogTimestamp {return false}
-    if lhs.eventApiTimestamp != rhs.eventApiTimestamp {return false}
-    if lhs.logTimestamp != rhs.logTimestamp {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/PromotedCore/SchemaProtos/proto_delivery_delivery.pb.swift
+++ b/Sources/PromotedCore/SchemaProtos/proto_delivery_delivery.pb.swift
@@ -22,7 +22,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 /// Used to indicate the client's use case.  Used on both View and Request.
 ///
-/// Next ID = 11.
+/// Next ID = 12.
 public enum Delivery_UseCase: SwiftProtobuf.Enum {
   public typealias RawValue = Int
   case unknownUseCase // = 0
@@ -38,6 +38,7 @@ public enum Delivery_UseCase: SwiftProtobuf.Enum {
   case myContent // = 8
   case mySavedContent // = 9
   case sellerContent // = 10
+  case discover // = 11
   case UNRECOGNIZED(Int)
 
   public init() {
@@ -57,6 +58,7 @@ public enum Delivery_UseCase: SwiftProtobuf.Enum {
     case 8: self = .myContent
     case 9: self = .mySavedContent
     case 10: self = .sellerContent
+    case 11: self = .discover
     default: self = .UNRECOGNIZED(rawValue)
     }
   }
@@ -74,6 +76,7 @@ public enum Delivery_UseCase: SwiftProtobuf.Enum {
     case .myContent: return 8
     case .mySavedContent: return 9
     case .sellerContent: return 10
+    case .discover: return 11
     case .UNRECOGNIZED(let i): return i
     }
   }
@@ -96,6 +99,7 @@ extension Delivery_UseCase: CaseIterable {
     .myContent,
     .mySavedContent,
     .sellerContent,
+    .discover,
   ]
 }
 
@@ -105,7 +109,7 @@ extension Delivery_UseCase: CaseIterable {
 /// Can be used to log existing ranking (not Promoted) or Promoted's Delivery
 /// API requests.
 ///
-/// Next ID = 17.
+/// Next ID = 18.
 public struct Delivery_Request {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -138,6 +142,16 @@ public struct Delivery_Request {
   public var hasTiming: Bool {return _storage._timing != nil}
   /// Clears the value of `timing`. Subsequent reads from it will return its default value.
   public mutating func clearTiming() {_uniqueStorage()._timing = nil}
+
+  /// Optional.  If not set, API server uses LogRequest.client_info.
+  public var clientInfo: Common_ClientInfo {
+    get {return _storage._clientInfo ?? Common_ClientInfo()}
+    set {_uniqueStorage()._clientInfo = newValue}
+  }
+  /// Returns true if `clientInfo` has been explicitly set.
+  public var hasClientInfo: Bool {return _storage._clientInfo != nil}
+  /// Clears the value of `clientInfo`. Subsequent reads from it will return its default value.
+  public mutating func clearClientInfo() {_uniqueStorage()._clientInfo = nil}
 
   /// Optional.  Primary key.
   /// SDKs usually handles this automatically. For details, see
@@ -184,10 +198,21 @@ public struct Delivery_Request {
   }
 
   /// Optional. Number of Insertions to return.
+  /// DEPRECATED: use paging intead.
   public var limit: Int32 {
     get {return _storage._limit}
     set {_uniqueStorage()._limit = newValue}
   }
+
+  /// Optional. Set to request a specific "page" of results.
+  public var paging: Delivery_Paging {
+    get {return _storage._paging ?? Delivery_Paging()}
+    set {_uniqueStorage()._paging = newValue}
+  }
+  /// Returns true if `paging` has been explicitly set.
+  public var hasPaging: Bool {return _storage._paging != nil}
+  /// Clears the value of `paging`. Subsequent reads from it will return its default value.
+  public mutating func clearPaging() {_uniqueStorage()._paging = nil}
 
   /// Optional.
   /// If set in Delivery API, Promoted will re-rank this list of Content.
@@ -226,7 +251,91 @@ public struct Delivery_Request {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-/// Next ID = 3.
+/// Next ID = 5.
+public struct Delivery_Paging {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Identity for the paging request (opaque token).
+  /// A single paging_id will have many associated requests to get the fully
+  /// paged response set (hence, many request_id's and client_request_id's).
+  ///
+  /// Required if using the cursor for the last_index; optional if using offset.
+  /// Setting this value provides better paging consistency/stability.  Ideally,
+  /// it should be set from the initial paging response
+  /// (Response.paging_info.paging_id).
+  ///
+  /// An external value can be used when *not* using promoted.ai's item
+  /// datastore.  The value must be specific enough to be globally unique, yet
+  /// general enough to ignore paging parameters.  A good example of a useful,
+  /// externally set paging_id is to use the paging token or identifiers returned
+  /// by your item datastore retrieval while passing the eligible insertions in
+  /// the Request.  If in doubt, rely on the Response.paging_info.paging_id or
+  /// contact us.
+  public var pagingID: String = String()
+
+  /// Required.  The number of items (insertions) to return.
+  public var size: Int32 = 0
+
+  /// Required.  The position of the first item of this page.
+  /// For example, to get the 5th page of results with a paging size of 10:
+  /// * cursor is an opaque token, so it should be the value returned
+  ///   by the 4th page response (Response.paging_info.cursor).
+  /// * offset is a 0-based index, so it should be set to 40.
+  public var starting: Delivery_Paging.OneOf_Starting? = nil
+
+  public var cursor: String {
+    get {
+      if case .cursor(let v)? = starting {return v}
+      return String()
+    }
+    set {starting = .cursor(newValue)}
+  }
+
+  public var offset: Int32 {
+    get {
+      if case .offset(let v)? = starting {return v}
+      return 0
+    }
+    set {starting = .offset(newValue)}
+  }
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  /// Required.  The position of the first item of this page.
+  /// For example, to get the 5th page of results with a paging size of 10:
+  /// * cursor is an opaque token, so it should be the value returned
+  ///   by the 4th page response (Response.paging_info.cursor).
+  /// * offset is a 0-based index, so it should be set to 40.
+  public enum OneOf_Starting: Equatable {
+    case cursor(String)
+    case offset(Int32)
+
+  #if !swift(>=4.1)
+    public static func ==(lhs: Delivery_Paging.OneOf_Starting, rhs: Delivery_Paging.OneOf_Starting) -> Bool {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch (lhs, rhs) {
+      case (.cursor, .cursor): return {
+        guard case .cursor(let l) = lhs, case .cursor(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      case (.offset, .offset): return {
+        guard case .offset(let l) = lhs, case .offset(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      default: return false
+      }
+    }
+  #endif
+  }
+
+  public init() {}
+}
+
+/// Next ID = 4.
 public struct Delivery_Response {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -234,6 +343,36 @@ public struct Delivery_Response {
 
   /// List of content.
   public var insertion: [Delivery_Insertion] = []
+
+  /// Paging information of this response.  Only returned on paging requests.
+  public var pagingInfo: Delivery_PagingInfo {
+    get {return _pagingInfo ?? Delivery_PagingInfo()}
+    set {_pagingInfo = newValue}
+  }
+  /// Returns true if `pagingInfo` has been explicitly set.
+  public var hasPagingInfo: Bool {return self._pagingInfo != nil}
+  /// Clears the value of `pagingInfo`. Subsequent reads from it will return its default value.
+  public mutating func clearPagingInfo() {self._pagingInfo = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _pagingInfo: Delivery_PagingInfo? = nil
+}
+
+/// Next ID = 3.
+public struct Delivery_PagingInfo {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Opaque identifier to be used in subsequent paging requests for a specific
+  /// paged repsonse set.
+  public var pagingID: String = String()
+
+  /// Opaque token that represents the last item index of this response.
+  public var cursor: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -271,6 +410,16 @@ public struct Delivery_Insertion {
   /// Clears the value of `timing`. Subsequent reads from it will return its default value.
   public mutating func clearTiming() {self._timing = nil}
 
+  /// Optional.  If not set, API server uses LogRequest.client_info.
+  public var clientInfo: Common_ClientInfo {
+    get {return _clientInfo ?? Common_ClientInfo()}
+    set {_clientInfo = newValue}
+  }
+  /// Returns true if `clientInfo` has been explicitly set.
+  public var hasClientInfo: Bool {return self._clientInfo != nil}
+  /// Clears the value of `clientInfo`. Subsequent reads from it will return its default value.
+  public mutating func clearClientInfo() {self._clientInfo = nil}
+
   /// Optional.  Primary key.
   /// SDKs usually handles this automatically. For details, see
   /// https://github.com/promotedai/schema#setting-primary-keys
@@ -288,7 +437,7 @@ public struct Delivery_Insertion {
   /// Optional.  We'll look this up using the external_content_id.
   public var contentID: String = String()
 
-  /// Optional.  0-based. Set by the customer, not by Promoted.
+  /// Optional.  0-based. As set by the customer, not by Promoted allocation.
   public var position: UInt64 = 0
 
   /// Optional. Custom item attributes and features set by customers.
@@ -307,6 +456,7 @@ public struct Delivery_Insertion {
 
   fileprivate var _userInfo: Common_UserInfo? = nil
   fileprivate var _timing: Common_Timing? = nil
+  fileprivate var _clientInfo: Common_ClientInfo? = nil
   fileprivate var _properties: Common_Properties? = nil
 }
 
@@ -327,6 +477,7 @@ extension Delivery_UseCase: SwiftProtobuf._ProtoNameProviding {
     8: .same(proto: "MY_CONTENT"),
     9: .same(proto: "MY_SAVED_CONTENT"),
     10: .same(proto: "SELLER_CONTENT"),
+    11: .same(proto: "DISCOVER"),
   ]
 }
 
@@ -336,6 +487,7 @@ extension Delivery_Request: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
     1: .standard(proto: "platform_id"),
     2: .standard(proto: "user_info"),
     3: .same(proto: "timing"),
+    4: .standard(proto: "client_info"),
     6: .standard(proto: "request_id"),
     7: .standard(proto: "view_id"),
     8: .standard(proto: "session_id"),
@@ -343,6 +495,7 @@ extension Delivery_Request: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
     9: .standard(proto: "use_case"),
     10: .standard(proto: "search_query"),
     15: .same(proto: "limit"),
+    17: .same(proto: "paging"),
     11: .same(proto: "insertion"),
     12: .standard(proto: "blender_config"),
     13: .same(proto: "properties"),
@@ -352,6 +505,7 @@ extension Delivery_Request: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
     var _platformID: UInt64 = 0
     var _userInfo: Common_UserInfo? = nil
     var _timing: Common_Timing? = nil
+    var _clientInfo: Common_ClientInfo? = nil
     var _requestID: String = String()
     var _viewID: String = String()
     var _sessionID: String = String()
@@ -359,6 +513,7 @@ extension Delivery_Request: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
     var _useCase: Delivery_UseCase = .unknownUseCase
     var _searchQuery: String = String()
     var _limit: Int32 = 0
+    var _paging: Delivery_Paging? = nil
     var _insertion: [Delivery_Insertion] = []
     var _blenderConfig: Delivery_BlenderConfig? = nil
     var _properties: Common_Properties? = nil
@@ -371,6 +526,7 @@ extension Delivery_Request: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
       _platformID = source._platformID
       _userInfo = source._userInfo
       _timing = source._timing
+      _clientInfo = source._clientInfo
       _requestID = source._requestID
       _viewID = source._viewID
       _sessionID = source._sessionID
@@ -378,6 +534,7 @@ extension Delivery_Request: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
       _useCase = source._useCase
       _searchQuery = source._searchQuery
       _limit = source._limit
+      _paging = source._paging
       _insertion = source._insertion
       _blenderConfig = source._blenderConfig
       _properties = source._properties
@@ -402,6 +559,7 @@ extension Delivery_Request: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
         case 1: try { try decoder.decodeSingularUInt64Field(value: &_storage._platformID) }()
         case 2: try { try decoder.decodeSingularMessageField(value: &_storage._userInfo) }()
         case 3: try { try decoder.decodeSingularMessageField(value: &_storage._timing) }()
+        case 4: try { try decoder.decodeSingularMessageField(value: &_storage._clientInfo) }()
         case 6: try { try decoder.decodeSingularStringField(value: &_storage._requestID) }()
         case 7: try { try decoder.decodeSingularStringField(value: &_storage._viewID) }()
         case 8: try { try decoder.decodeSingularStringField(value: &_storage._sessionID) }()
@@ -412,6 +570,7 @@ extension Delivery_Request: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
         case 13: try { try decoder.decodeSingularMessageField(value: &_storage._properties) }()
         case 14: try { try decoder.decodeSingularStringField(value: &_storage._clientRequestID) }()
         case 15: try { try decoder.decodeSingularInt32Field(value: &_storage._limit) }()
+        case 17: try { try decoder.decodeSingularMessageField(value: &_storage._paging) }()
         default: break
         }
       }
@@ -428,6 +587,9 @@ extension Delivery_Request: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
       }
       if let v = _storage._timing {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
+      if let v = _storage._clientInfo {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
       }
       if !_storage._requestID.isEmpty {
         try visitor.visitSingularStringField(value: _storage._requestID, fieldNumber: 6)
@@ -459,6 +621,9 @@ extension Delivery_Request: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
       if _storage._limit != 0 {
         try visitor.visitSingularInt32Field(value: _storage._limit, fieldNumber: 15)
       }
+      if let v = _storage._paging {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -471,6 +636,7 @@ extension Delivery_Request: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
         if _storage._platformID != rhs_storage._platformID {return false}
         if _storage._userInfo != rhs_storage._userInfo {return false}
         if _storage._timing != rhs_storage._timing {return false}
+        if _storage._clientInfo != rhs_storage._clientInfo {return false}
         if _storage._requestID != rhs_storage._requestID {return false}
         if _storage._viewID != rhs_storage._viewID {return false}
         if _storage._sessionID != rhs_storage._sessionID {return false}
@@ -478,6 +644,7 @@ extension Delivery_Request: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
         if _storage._useCase != rhs_storage._useCase {return false}
         if _storage._searchQuery != rhs_storage._searchQuery {return false}
         if _storage._limit != rhs_storage._limit {return false}
+        if _storage._paging != rhs_storage._paging {return false}
         if _storage._insertion != rhs_storage._insertion {return false}
         if _storage._blenderConfig != rhs_storage._blenderConfig {return false}
         if _storage._properties != rhs_storage._properties {return false}
@@ -490,10 +657,78 @@ extension Delivery_Request: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
   }
 }
 
+extension Delivery_Paging: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".Paging"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "paging_id"),
+    2: .same(proto: "size"),
+    3: .same(proto: "cursor"),
+    4: .same(proto: "offset"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.pagingID) }()
+      case 2: try { try decoder.decodeSingularInt32Field(value: &self.size) }()
+      case 3: try {
+        if self.starting != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.starting = .cursor(v)}
+      }()
+      case 4: try {
+        if self.starting != nil {try decoder.handleConflictingOneOf()}
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {self.starting = .offset(v)}
+      }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.pagingID.isEmpty {
+      try visitor.visitSingularStringField(value: self.pagingID, fieldNumber: 1)
+    }
+    if self.size != 0 {
+      try visitor.visitSingularInt32Field(value: self.size, fieldNumber: 2)
+    }
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every case branch when no optimizations are
+    // enabled. https://github.com/apple/swift-protobuf/issues/1034
+    switch self.starting {
+    case .cursor?: try {
+      guard case .cursor(let v)? = self.starting else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+    }()
+    case .offset?: try {
+      guard case .offset(let v)? = self.starting else { preconditionFailure() }
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 4)
+    }()
+    case nil: break
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Delivery_Paging, rhs: Delivery_Paging) -> Bool {
+    if lhs.pagingID != rhs.pagingID {return false}
+    if lhs.size != rhs.size {return false}
+    if lhs.starting != rhs.starting {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
 extension Delivery_Response: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Response"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     2: .same(proto: "insertion"),
+    3: .standard(proto: "paging_info"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -503,6 +738,7 @@ extension Delivery_Response: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 2: try { try decoder.decodeRepeatedMessageField(value: &self.insertion) }()
+      case 3: try { try decoder.decodeSingularMessageField(value: &self._pagingInfo) }()
       default: break
       }
     }
@@ -512,11 +748,53 @@ extension Delivery_Response: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
     if !self.insertion.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.insertion, fieldNumber: 2)
     }
+    if let v = self._pagingInfo {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Delivery_Response, rhs: Delivery_Response) -> Bool {
     if lhs.insertion != rhs.insertion {return false}
+    if lhs._pagingInfo != rhs._pagingInfo {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Delivery_PagingInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".PagingInfo"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "paging_id"),
+    2: .same(proto: "cursor"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.pagingID) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.cursor) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.pagingID.isEmpty {
+      try visitor.visitSingularStringField(value: self.pagingID, fieldNumber: 1)
+    }
+    if !self.cursor.isEmpty {
+      try visitor.visitSingularStringField(value: self.cursor, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Delivery_PagingInfo, rhs: Delivery_PagingInfo) -> Bool {
+    if lhs.pagingID != rhs.pagingID {return false}
+    if lhs.cursor != rhs.cursor {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -528,6 +806,7 @@ extension Delivery_Insertion: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
     1: .standard(proto: "platform_id"),
     2: .standard(proto: "user_info"),
     3: .same(proto: "timing"),
+    4: .standard(proto: "client_info"),
     6: .standard(proto: "insertion_id"),
     7: .standard(proto: "request_id"),
     9: .standard(proto: "view_id"),
@@ -546,6 +825,7 @@ extension Delivery_Insertion: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
       case 1: try { try decoder.decodeSingularUInt64Field(value: &self.platformID) }()
       case 2: try { try decoder.decodeSingularMessageField(value: &self._userInfo) }()
       case 3: try { try decoder.decodeSingularMessageField(value: &self._timing) }()
+      case 4: try { try decoder.decodeSingularMessageField(value: &self._clientInfo) }()
       case 6: try { try decoder.decodeSingularStringField(value: &self.insertionID) }()
       case 7: try { try decoder.decodeSingularStringField(value: &self.requestID) }()
       case 8: try { try decoder.decodeSingularStringField(value: &self.sessionID) }()
@@ -567,6 +847,9 @@ extension Delivery_Insertion: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
     }
     if let v = self._timing {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }
+    if let v = self._clientInfo {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
     }
     if !self.insertionID.isEmpty {
       try visitor.visitSingularStringField(value: self.insertionID, fieldNumber: 6)
@@ -596,6 +879,7 @@ extension Delivery_Insertion: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
     if lhs.platformID != rhs.platformID {return false}
     if lhs._userInfo != rhs._userInfo {return false}
     if lhs._timing != rhs._timing {return false}
+    if lhs._clientInfo != rhs._clientInfo {return false}
     if lhs.insertionID != rhs.insertionID {return false}
     if lhs.requestID != rhs.requestID {return false}
     if lhs.viewID != rhs.viewID {return false}

--- a/Sources/PromotedCore/SchemaProtos/proto_event_event.pb.swift
+++ b/Sources/PromotedCore/SchemaProtos/proto_event_event.pb.swift
@@ -129,6 +129,58 @@ extension Event_DeviceType: CaseIterable {
 
 #endif  // swift(>=4.2)
 
+/// Contextual information about where impression was served.
+/// Allows backends to infer expected behavior about
+/// corresponding content.
+/// Next ID = 3.
+public enum Event_ImpressionSourceType: SwiftProtobuf.Enum {
+  public typealias RawValue = Int
+  case unknownImpressionSourceType // = 0
+
+  /// Content was served by Promoted Delivery API.
+  case delivery // = 1
+
+  /// Content was not served by Promoted Delivery API.
+  case clientBackend // = 2
+  case UNRECOGNIZED(Int)
+
+  public init() {
+    self = .unknownImpressionSourceType
+  }
+
+  public init?(rawValue: Int) {
+    switch rawValue {
+    case 0: self = .unknownImpressionSourceType
+    case 1: self = .delivery
+    case 2: self = .clientBackend
+    default: self = .UNRECOGNIZED(rawValue)
+    }
+  }
+
+  public var rawValue: Int {
+    switch self {
+    case .unknownImpressionSourceType: return 0
+    case .delivery: return 1
+    case .clientBackend: return 2
+    case .UNRECOGNIZED(let i): return i
+    }
+  }
+
+}
+
+#if swift(>=4.2)
+
+extension Event_ImpressionSourceType: CaseIterable {
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  public static var allCases: [Event_ImpressionSourceType] = [
+    .unknownImpressionSourceType,
+    .delivery,
+    .clientBackend,
+  ]
+}
+
+#endif  // swift(>=4.2)
+
 /// The action that user wants to perform.
 ///
 /// Next ID = 16.
@@ -324,6 +376,16 @@ public struct Event_User {
   /// Clears the value of `timing`. Subsequent reads from it will return its default value.
   public mutating func clearTiming() {self._timing = nil}
 
+  /// Optional.  If not set, API server uses LogRequest.client_info.
+  public var clientInfo: Common_ClientInfo {
+    get {return _clientInfo ?? Common_ClientInfo()}
+    set {_clientInfo = newValue}
+  }
+  /// Returns true if `clientInfo` has been explicitly set.
+  public var hasClientInfo: Bool {return self._clientInfo != nil}
+  /// Clears the value of `clientInfo`. Subsequent reads from it will return its default value.
+  public mutating func clearClientInfo() {self._clientInfo = nil}
+
   /// Optional.  Custom properties per platform.
   public var properties: Common_Properties {
     get {return _properties ?? Common_Properties()}
@@ -340,6 +402,7 @@ public struct Event_User {
 
   fileprivate var _userInfo: Common_UserInfo? = nil
   fileprivate var _timing: Common_Timing? = nil
+  fileprivate var _clientInfo: Common_ClientInfo? = nil
   fileprivate var _properties: Common_Properties? = nil
 }
 
@@ -375,6 +438,16 @@ public struct Event_CohortMembership {
   /// Clears the value of `timing`. Subsequent reads from it will return its default value.
   public mutating func clearTiming() {self._timing = nil}
 
+  /// Optional.  If not set, API server uses LogRequest.client_info.
+  public var clientInfo: Common_ClientInfo {
+    get {return _clientInfo ?? Common_ClientInfo()}
+    set {_clientInfo = newValue}
+  }
+  /// Returns true if `clientInfo` has been explicitly set.
+  public var hasClientInfo: Bool {return self._clientInfo != nil}
+  /// Clears the value of `clientInfo`. Subsequent reads from it will return its default value.
+  public mutating func clearClientInfo() {self._clientInfo = nil}
+
   /// Optional.  Primary key.
   /// SDKs usually handles this automatically. For details, see
   /// https://github.com/promotedai/schema#setting-primary-keys
@@ -402,6 +475,7 @@ public struct Event_CohortMembership {
 
   fileprivate var _userInfo: Common_UserInfo? = nil
   fileprivate var _timing: Common_Timing? = nil
+  fileprivate var _clientInfo: Common_ClientInfo? = nil
   fileprivate var _properties: Common_Properties? = nil
 }
 
@@ -707,6 +781,16 @@ public struct Event_View {
   /// Clears the value of `timing`. Subsequent reads from it will return its default value.
   public mutating func clearTiming() {_uniqueStorage()._timing = nil}
 
+  /// Optional.  If not set, API server uses LogRequest.client_info.
+  public var clientInfo: Common_ClientInfo {
+    get {return _storage._clientInfo ?? Common_ClientInfo()}
+    set {_uniqueStorage()._clientInfo = newValue}
+  }
+  /// Returns true if `clientInfo` has been explicitly set.
+  public var hasClientInfo: Bool {return _storage._clientInfo != nil}
+  /// Clears the value of `clientInfo`. Subsequent reads from it will return its default value.
+  public mutating func clearClientInfo() {_uniqueStorage()._clientInfo = nil}
+
   /// Optional.  Primary key.
   /// SDKs usually handles this automatically. For details, see
   /// https://github.com/promotedai/schema#setting-primary-keys
@@ -768,7 +852,9 @@ public struct Event_View {
   /// Clears the value of `locale`. Subsequent reads from it will return its default value.
   public mutating func clearLocale() {_uniqueStorage()._locale = nil}
 
-  /// Next ID = 5.
+  /// If a specific view is set (`web_page_view` and `app_screen_view`),
+  /// clients do not need to set it directly.  If those fields and `view_type`
+  /// have conflicting values, the specific view field is used.
   public var viewType: Event_View.ViewType {
     get {return _storage._viewType}
     set {_uniqueStorage()._viewType = newValue}
@@ -872,7 +958,7 @@ extension Event_View.ViewType: CaseIterable {
 
 /// When an Insertion (instance of Content) is shown to a user.
 /// Impressions are immutable.
-/// Next ID = 13.
+/// Next ID = 14.
 public struct Event_Impression {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -903,6 +989,16 @@ public struct Event_Impression {
   /// Clears the value of `timing`. Subsequent reads from it will return its default value.
   public mutating func clearTiming() {self._timing = nil}
 
+  /// Optional.  If not set, API server uses LogRequest.client_info.
+  public var clientInfo: Common_ClientInfo {
+    get {return _clientInfo ?? Common_ClientInfo()}
+    set {_clientInfo = newValue}
+  }
+  /// Returns true if `clientInfo` has been explicitly set.
+  public var hasClientInfo: Bool {return self._clientInfo != nil}
+  /// Clears the value of `clientInfo`. Subsequent reads from it will return its default value.
+  public mutating func clearClientInfo() {self._clientInfo = nil}
+
   /// Optional.  Primary key.
   /// SDKs usually handles this automatically. For details, see
   /// https://github.com/promotedai/schema#setting-primary-keys
@@ -924,6 +1020,9 @@ public struct Event_Impression {
   /// For more accurate results, set insertion_id.
   public var contentID: String = String()
 
+  /// Optional.
+  public var sourceType: Event_ImpressionSourceType = .unknownImpressionSourceType
+
   /// Optional.  Custom properties per platform.
   public var properties: Common_Properties {
     get {return _properties ?? Common_Properties()}
@@ -940,6 +1039,7 @@ public struct Event_Impression {
 
   fileprivate var _userInfo: Common_UserInfo? = nil
   fileprivate var _timing: Common_Timing? = nil
+  fileprivate var _clientInfo: Common_ClientInfo? = nil
   fileprivate var _properties: Common_Properties? = nil
 }
 
@@ -992,6 +1092,16 @@ public struct Event_Action {
   public var hasTiming: Bool {return _storage._timing != nil}
   /// Clears the value of `timing`. Subsequent reads from it will return its default value.
   public mutating func clearTiming() {_uniqueStorage()._timing = nil}
+
+  /// Optional.  If not set, API server uses LogRequest.client_info.
+  public var clientInfo: Common_ClientInfo {
+    get {return _storage._clientInfo ?? Common_ClientInfo()}
+    set {_uniqueStorage()._clientInfo = newValue}
+  }
+  /// Returns true if `clientInfo` has been explicitly set.
+  public var hasClientInfo: Bool {return _storage._clientInfo != nil}
+  /// Clears the value of `clientInfo`. Subsequent reads from it will return its default value.
+  public mutating func clearClientInfo() {_uniqueStorage()._clientInfo = nil}
 
   /// Optional.  Primary key.
   /// SDKs usually handles this automatically. For details, see
@@ -1110,6 +1220,258 @@ public struct Event_Action {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
+/// Error from iOS client.
+/// Next ID = 5.
+public struct Event_IOSError {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Error code from NSError.
+  public var code: Int32 = 0
+
+  /// Error domain from NSError.
+  public var domain: String = String()
+
+  /// Description of error.
+  public var description_p: String = String()
+
+  /// Which batch generated the error.
+  public var batchNumber: Int32 = 0
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// History of errors from client.
+/// Next ID = 3.
+public struct Event_ErrorHistory {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Window of latest errors.
+  public var iosErrors: [Event_IOSError] = []
+
+  /// Total number of errors encountered.
+  public var totalErrors: Int32 = 0
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// Ancestor ID either logged as event or external ID.
+/// Next ID = 6.
+public struct Event_AncestorIdHistoryItem {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Changed value of ancestor ID.
+  public var ancestorID: String = String()
+
+  /// Event that caused the change, if any.
+  public var loggedEvent: Event_AncestorIdHistoryItem.OneOf_LoggedEvent? = nil
+
+  public var userEvent: Event_User {
+    get {
+      if case .userEvent(let v)? = loggedEvent {return v}
+      return Event_User()
+    }
+    set {loggedEvent = .userEvent(newValue)}
+  }
+
+  /// Internally autogenerated session ID.
+  public var sessionIDFromUserEvent: String {
+    get {
+      if case .sessionIDFromUserEvent(let v)? = loggedEvent {return v}
+      return String()
+    }
+    set {loggedEvent = .sessionIDFromUserEvent(newValue)}
+  }
+
+  public var viewEvent: Event_View {
+    get {
+      if case .viewEvent(let v)? = loggedEvent {return v}
+      return Event_View()
+    }
+    set {loggedEvent = .viewEvent(newValue)}
+  }
+
+  /// Which batch number the event was logged in
+  public var batchNumber: Int32 = 0
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  /// Event that caused the change, if any.
+  public enum OneOf_LoggedEvent: Equatable {
+    case userEvent(Event_User)
+    /// Internally autogenerated session ID.
+    case sessionIDFromUserEvent(String)
+    case viewEvent(Event_View)
+
+  #if !swift(>=4.1)
+    public static func ==(lhs: Event_AncestorIdHistoryItem.OneOf_LoggedEvent, rhs: Event_AncestorIdHistoryItem.OneOf_LoggedEvent) -> Bool {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch (lhs, rhs) {
+      case (.userEvent, .userEvent): return {
+        guard case .userEvent(let l) = lhs, case .userEvent(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      case (.sessionIDFromUserEvent, .sessionIDFromUserEvent): return {
+        guard case .sessionIDFromUserEvent(let l) = lhs, case .sessionIDFromUserEvent(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      case (.viewEvent, .viewEvent): return {
+        guard case .viewEvent(let l) = lhs, case .viewEvent(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      default: return false
+      }
+    }
+  #endif
+  }
+
+  public init() {}
+}
+
+/// History of ancestor IDs logged by client.
+/// Next ID = 7.
+public struct Event_AncestorIdHistory {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Window of latest log user ids.
+  public var ancestorIDHistory: [Event_AncestorIdHistoryItem] = []
+
+  /// Total number of log user ids logged this session.
+  public var totalLogUserIdsLogged: Int32 = 0
+
+  /// Window of latest session ids.
+  public var sessionIDHistory: [Event_AncestorIdHistoryItem] = []
+
+  /// Total number of session ids logged this session.
+  public var totalSessionIdsLogged: Int32 = 0
+
+  /// Window of latest view ids.
+  public var viewIDHistory: [Event_AncestorIdHistoryItem] = []
+
+  /// Total number of view ids logged this session.
+  public var totalViewIdsLogged: Int32 = 0
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// Diagnostic information for mobile clients.
+/// Next ID = 13.
+public struct Event_MobileDiagnostics {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Common fields.
+  public var platformID: UInt64 {
+    get {return _storage._platformID}
+    set {_uniqueStorage()._platformID = newValue}
+  }
+
+  public var userInfo: Common_UserInfo {
+    get {return _storage._userInfo ?? Common_UserInfo()}
+    set {_uniqueStorage()._userInfo = newValue}
+  }
+  /// Returns true if `userInfo` has been explicitly set.
+  public var hasUserInfo: Bool {return _storage._userInfo != nil}
+  /// Clears the value of `userInfo`. Subsequent reads from it will return its default value.
+  public mutating func clearUserInfo() {_uniqueStorage()._userInfo = nil}
+
+  public var timing: Common_Timing {
+    get {return _storage._timing ?? Common_Timing()}
+    set {_uniqueStorage()._timing = newValue}
+  }
+  /// Returns true if `timing` has been explicitly set.
+  public var hasTiming: Bool {return _storage._timing != nil}
+  /// Clears the value of `timing`. Subsequent reads from it will return its default value.
+  public mutating func clearTiming() {_uniqueStorage()._timing = nil}
+
+  public var clientInfo: Common_ClientInfo {
+    get {return _storage._clientInfo ?? Common_ClientInfo()}
+    set {_uniqueStorage()._clientInfo = newValue}
+  }
+  /// Returns true if `clientInfo` has been explicitly set.
+  public var hasClientInfo: Bool {return _storage._clientInfo != nil}
+  /// Clears the value of `clientInfo`. Subsequent reads from it will return its default value.
+  public mutating func clearClientInfo() {_uniqueStorage()._clientInfo = nil}
+
+  /// Unique identifier for device sending this message.
+  public var deviceIdentifier: String {
+    get {return _storage._deviceIdentifier}
+    set {_uniqueStorage()._deviceIdentifier = newValue}
+  }
+
+  /// Version identifier for client app.
+  public var clientVersion: String {
+    get {return _storage._clientVersion}
+    set {_uniqueStorage()._clientVersion = newValue}
+  }
+
+  /// Version of Promoted library.
+  public var promotedLibraryVersion: String {
+    get {return _storage._promotedLibraryVersion}
+    set {_uniqueStorage()._promotedLibraryVersion = newValue}
+  }
+
+  /// Number of batch logs attempted.
+  public var batchesAttempted: Int32 {
+    get {return _storage._batchesAttempted}
+    set {_uniqueStorage()._batchesAttempted = newValue}
+  }
+
+  /// Number of batch logs sent successfully.
+  public var batchesSentSuccessfully: Int32 {
+    get {return _storage._batchesSentSuccessfully}
+    set {_uniqueStorage()._batchesSentSuccessfully = newValue}
+  }
+
+  /// Number of batch logs that failed to send.
+  public var batchesWithErrors: Int32 {
+    get {return _storage._batchesWithErrors}
+    set {_uniqueStorage()._batchesWithErrors = newValue}
+  }
+
+  /// Error history.
+  public var errorHistory: Event_ErrorHistory {
+    get {return _storage._errorHistory ?? Event_ErrorHistory()}
+    set {_uniqueStorage()._errorHistory = newValue}
+  }
+  /// Returns true if `errorHistory` has been explicitly set.
+  public var hasErrorHistory: Bool {return _storage._errorHistory != nil}
+  /// Clears the value of `errorHistory`. Subsequent reads from it will return its default value.
+  public mutating func clearErrorHistory() {_uniqueStorage()._errorHistory = nil}
+
+  /// Ancestor ID history. See #133.
+  public var ancestorIDHistory: Event_AncestorIdHistory {
+    get {return _storage._ancestorIDHistory ?? Event_AncestorIdHistory()}
+    set {_uniqueStorage()._ancestorIDHistory = newValue}
+  }
+  /// Returns true if `ancestorIDHistory` has been explicitly set.
+  public var hasAncestorIDHistory: Bool {return _storage._ancestorIDHistory != nil}
+  /// Clears the value of `ancestorIDHistory`. Subsequent reads from it will return its default value.
+  public mutating func clearAncestorIDHistory() {_uniqueStorage()._ancestorIDHistory = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
+}
+
 /// A way to batch up log requests into the same request.
 /// Clients can reference logs in different batches.
 /// Next ID = 17.
@@ -1143,6 +1505,16 @@ public struct Event_LogRequest {
   /// Clears the value of `timing`. Subsequent reads from it will return its default value.
   public mutating func clearTiming() {self._timing = nil}
 
+  /// Optional.
+  public var clientInfo: Common_ClientInfo {
+    get {return _clientInfo ?? Common_ClientInfo()}
+    set {_clientInfo = newValue}
+  }
+  /// Returns true if `clientInfo` has been explicitly set.
+  public var hasClientInfo: Bool {return self._clientInfo != nil}
+  /// Clears the value of `clientInfo`. Subsequent reads from it will return its default value.
+  public mutating func clearClientInfo() {self._clientInfo = nil}
+
   public var user: [Event_User] = []
 
   public var cohortMembership: [Event_CohortMembership] = []
@@ -1157,12 +1529,23 @@ public struct Event_LogRequest {
 
   public var action: [Event_Action] = []
 
+  public var mobileDiagnostics: Event_MobileDiagnostics {
+    get {return _mobileDiagnostics ?? Event_MobileDiagnostics()}
+    set {_mobileDiagnostics = newValue}
+  }
+  /// Returns true if `mobileDiagnostics` has been explicitly set.
+  public var hasMobileDiagnostics: Bool {return self._mobileDiagnostics != nil}
+  /// Clears the value of `mobileDiagnostics`. Subsequent reads from it will return its default value.
+  public mutating func clearMobileDiagnostics() {self._mobileDiagnostics = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
   fileprivate var _userInfo: Common_UserInfo? = nil
   fileprivate var _timing: Common_Timing? = nil
+  fileprivate var _clientInfo: Common_ClientInfo? = nil
+  fileprivate var _mobileDiagnostics: Event_MobileDiagnostics? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -1186,6 +1569,14 @@ extension Event_DeviceType: SwiftProtobuf._ProtoNameProviding {
     1: .same(proto: "DESKTOP"),
     2: .same(proto: "MOBILE"),
     3: .same(proto: "TABLET"),
+  ]
+}
+
+extension Event_ImpressionSourceType: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "UNKNOWN_IMPRESSION_SOURCE_TYPE"),
+    1: .same(proto: "DELIVERY"),
+    2: .same(proto: "CLIENT_BACKEND"),
   ]
 }
 
@@ -1290,6 +1681,7 @@ extension Event_User: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementatio
     1: .standard(proto: "platform_id"),
     2: .standard(proto: "user_info"),
     3: .same(proto: "timing"),
+    4: .standard(proto: "client_info"),
     6: .same(proto: "properties"),
   ]
 
@@ -1302,6 +1694,7 @@ extension Event_User: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementatio
       case 1: try { try decoder.decodeSingularUInt64Field(value: &self.platformID) }()
       case 2: try { try decoder.decodeSingularMessageField(value: &self._userInfo) }()
       case 3: try { try decoder.decodeSingularMessageField(value: &self._timing) }()
+      case 4: try { try decoder.decodeSingularMessageField(value: &self._clientInfo) }()
       case 6: try { try decoder.decodeSingularMessageField(value: &self._properties) }()
       default: break
       }
@@ -1318,6 +1711,9 @@ extension Event_User: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementatio
     if let v = self._timing {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     }
+    if let v = self._clientInfo {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    }
     if let v = self._properties {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
     }
@@ -1328,6 +1724,7 @@ extension Event_User: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementatio
     if lhs.platformID != rhs.platformID {return false}
     if lhs._userInfo != rhs._userInfo {return false}
     if lhs._timing != rhs._timing {return false}
+    if lhs._clientInfo != rhs._clientInfo {return false}
     if lhs._properties != rhs._properties {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -1340,6 +1737,7 @@ extension Event_CohortMembership: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     1: .standard(proto: "platform_id"),
     2: .standard(proto: "user_info"),
     3: .same(proto: "timing"),
+    4: .standard(proto: "client_info"),
     6: .standard(proto: "membership_id"),
     8: .standard(proto: "cohort_id"),
     9: .same(proto: "arm"),
@@ -1355,6 +1753,7 @@ extension Event_CohortMembership: SwiftProtobuf.Message, SwiftProtobuf._MessageI
       case 1: try { try decoder.decodeSingularUInt64Field(value: &self.platformID) }()
       case 2: try { try decoder.decodeSingularMessageField(value: &self._userInfo) }()
       case 3: try { try decoder.decodeSingularMessageField(value: &self._timing) }()
+      case 4: try { try decoder.decodeSingularMessageField(value: &self._clientInfo) }()
       case 6: try { try decoder.decodeSingularStringField(value: &self.membershipID) }()
       case 8: try { try decoder.decodeSingularStringField(value: &self.cohortID) }()
       case 9: try { try decoder.decodeSingularEnumField(value: &self.arm) }()
@@ -1373,6 +1772,9 @@ extension Event_CohortMembership: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     }
     if let v = self._timing {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }
+    if let v = self._clientInfo {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
     }
     if !self.membershipID.isEmpty {
       try visitor.visitSingularStringField(value: self.membershipID, fieldNumber: 6)
@@ -1393,6 +1795,7 @@ extension Event_CohortMembership: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     if lhs.platformID != rhs.platformID {return false}
     if lhs._userInfo != rhs._userInfo {return false}
     if lhs._timing != rhs._timing {return false}
+    if lhs._clientInfo != rhs._clientInfo {return false}
     if lhs.membershipID != rhs.membershipID {return false}
     if lhs.cohortID != rhs.cohortID {return false}
     if lhs.arm != rhs.arm {return false}
@@ -1847,6 +2250,7 @@ extension Event_View: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementatio
     1: .standard(proto: "platform_id"),
     2: .standard(proto: "user_info"),
     3: .same(proto: "timing"),
+    4: .standard(proto: "client_info"),
     6: .standard(proto: "view_id"),
     7: .standard(proto: "session_id"),
     8: .same(proto: "name"),
@@ -1864,6 +2268,7 @@ extension Event_View: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementatio
     var _platformID: UInt64 = 0
     var _userInfo: Common_UserInfo? = nil
     var _timing: Common_Timing? = nil
+    var _clientInfo: Common_ClientInfo? = nil
     var _viewID: String = String()
     var _sessionID: String = String()
     var _name: String = String()
@@ -1883,6 +2288,7 @@ extension Event_View: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementatio
       _platformID = source._platformID
       _userInfo = source._userInfo
       _timing = source._timing
+      _clientInfo = source._clientInfo
       _viewID = source._viewID
       _sessionID = source._sessionID
       _name = source._name
@@ -1914,6 +2320,7 @@ extension Event_View: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementatio
         case 1: try { try decoder.decodeSingularUInt64Field(value: &_storage._platformID) }()
         case 2: try { try decoder.decodeSingularMessageField(value: &_storage._userInfo) }()
         case 3: try { try decoder.decodeSingularMessageField(value: &_storage._timing) }()
+        case 4: try { try decoder.decodeSingularMessageField(value: &_storage._clientInfo) }()
         case 6: try { try decoder.decodeSingularStringField(value: &_storage._viewID) }()
         case 7: try { try decoder.decodeSingularStringField(value: &_storage._sessionID) }()
         case 8: try { try decoder.decodeSingularStringField(value: &_storage._name) }()
@@ -1957,6 +2364,9 @@ extension Event_View: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementatio
       }
       if let v = _storage._timing {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
+      if let v = _storage._clientInfo {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
       }
       if !_storage._viewID.isEmpty {
         try visitor.visitSingularStringField(value: _storage._viewID, fieldNumber: 6)
@@ -2011,6 +2421,7 @@ extension Event_View: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementatio
         if _storage._platformID != rhs_storage._platformID {return false}
         if _storage._userInfo != rhs_storage._userInfo {return false}
         if _storage._timing != rhs_storage._timing {return false}
+        if _storage._clientInfo != rhs_storage._clientInfo {return false}
         if _storage._viewID != rhs_storage._viewID {return false}
         if _storage._sessionID != rhs_storage._sessionID {return false}
         if _storage._name != rhs_storage._name {return false}
@@ -2044,12 +2455,14 @@ extension Event_Impression: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
     1: .standard(proto: "platform_id"),
     2: .standard(proto: "user_info"),
     3: .same(proto: "timing"),
+    4: .standard(proto: "client_info"),
     6: .standard(proto: "impression_id"),
     7: .standard(proto: "insertion_id"),
     8: .standard(proto: "request_id"),
     10: .standard(proto: "view_id"),
     9: .standard(proto: "session_id"),
     12: .standard(proto: "content_id"),
+    13: .standard(proto: "source_type"),
     11: .same(proto: "properties"),
   ]
 
@@ -2062,6 +2475,7 @@ extension Event_Impression: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
       case 1: try { try decoder.decodeSingularUInt64Field(value: &self.platformID) }()
       case 2: try { try decoder.decodeSingularMessageField(value: &self._userInfo) }()
       case 3: try { try decoder.decodeSingularMessageField(value: &self._timing) }()
+      case 4: try { try decoder.decodeSingularMessageField(value: &self._clientInfo) }()
       case 6: try { try decoder.decodeSingularStringField(value: &self.impressionID) }()
       case 7: try { try decoder.decodeSingularStringField(value: &self.insertionID) }()
       case 8: try { try decoder.decodeSingularStringField(value: &self.requestID) }()
@@ -2069,6 +2483,7 @@ extension Event_Impression: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
       case 10: try { try decoder.decodeSingularStringField(value: &self.viewID) }()
       case 11: try { try decoder.decodeSingularMessageField(value: &self._properties) }()
       case 12: try { try decoder.decodeSingularStringField(value: &self.contentID) }()
+      case 13: try { try decoder.decodeSingularEnumField(value: &self.sourceType) }()
       default: break
       }
     }
@@ -2083,6 +2498,9 @@ extension Event_Impression: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
     }
     if let v = self._timing {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }
+    if let v = self._clientInfo {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
     }
     if !self.impressionID.isEmpty {
       try visitor.visitSingularStringField(value: self.impressionID, fieldNumber: 6)
@@ -2105,6 +2523,9 @@ extension Event_Impression: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
     if !self.contentID.isEmpty {
       try visitor.visitSingularStringField(value: self.contentID, fieldNumber: 12)
     }
+    if self.sourceType != .unknownImpressionSourceType {
+      try visitor.visitSingularEnumField(value: self.sourceType, fieldNumber: 13)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -2112,12 +2533,14 @@ extension Event_Impression: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
     if lhs.platformID != rhs.platformID {return false}
     if lhs._userInfo != rhs._userInfo {return false}
     if lhs._timing != rhs._timing {return false}
+    if lhs._clientInfo != rhs._clientInfo {return false}
     if lhs.impressionID != rhs.impressionID {return false}
     if lhs.insertionID != rhs.insertionID {return false}
     if lhs.requestID != rhs.requestID {return false}
     if lhs.viewID != rhs.viewID {return false}
     if lhs.sessionID != rhs.sessionID {return false}
     if lhs.contentID != rhs.contentID {return false}
+    if lhs.sourceType != rhs.sourceType {return false}
     if lhs._properties != rhs._properties {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -2162,6 +2585,7 @@ extension Event_Action: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
     1: .standard(proto: "platform_id"),
     2: .standard(proto: "user_info"),
     3: .same(proto: "timing"),
+    4: .standard(proto: "client_info"),
     6: .standard(proto: "action_id"),
     7: .standard(proto: "impression_id"),
     8: .standard(proto: "insertion_id"),
@@ -2181,6 +2605,7 @@ extension Event_Action: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
     var _platformID: UInt64 = 0
     var _userInfo: Common_UserInfo? = nil
     var _timing: Common_Timing? = nil
+    var _clientInfo: Common_ClientInfo? = nil
     var _actionID: String = String()
     var _impressionID: String = String()
     var _insertionID: String = String()
@@ -2203,6 +2628,7 @@ extension Event_Action: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
       _platformID = source._platformID
       _userInfo = source._userInfo
       _timing = source._timing
+      _clientInfo = source._clientInfo
       _actionID = source._actionID
       _impressionID = source._impressionID
       _insertionID = source._insertionID
@@ -2237,6 +2663,7 @@ extension Event_Action: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
         case 1: try { try decoder.decodeSingularUInt64Field(value: &_storage._platformID) }()
         case 2: try { try decoder.decodeSingularMessageField(value: &_storage._userInfo) }()
         case 3: try { try decoder.decodeSingularMessageField(value: &_storage._timing) }()
+        case 4: try { try decoder.decodeSingularMessageField(value: &_storage._clientInfo) }()
         case 6: try { try decoder.decodeSingularStringField(value: &_storage._actionID) }()
         case 7: try { try decoder.decodeSingularStringField(value: &_storage._impressionID) }()
         case 8: try { try decoder.decodeSingularStringField(value: &_storage._insertionID) }()
@@ -2274,6 +2701,9 @@ extension Event_Action: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
       }
       if let v = _storage._timing {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
+      if let v = _storage._clientInfo {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
       }
       if !_storage._actionID.isEmpty {
         try visitor.visitSingularStringField(value: _storage._actionID, fieldNumber: 6)
@@ -2326,6 +2756,7 @@ extension Event_Action: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
         if _storage._platformID != rhs_storage._platformID {return false}
         if _storage._userInfo != rhs_storage._userInfo {return false}
         if _storage._timing != rhs_storage._timing {return false}
+        if _storage._clientInfo != rhs_storage._clientInfo {return false}
         if _storage._actionID != rhs_storage._actionID {return false}
         if _storage._impressionID != rhs_storage._impressionID {return false}
         if _storage._insertionID != rhs_storage._insertionID {return false}
@@ -2348,12 +2779,399 @@ extension Event_Action: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
   }
 }
 
+extension Event_IOSError: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".IOSError"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "code"),
+    2: .same(proto: "domain"),
+    3: .same(proto: "description"),
+    4: .standard(proto: "batch_number"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularInt32Field(value: &self.code) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.domain) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.description_p) }()
+      case 4: try { try decoder.decodeSingularInt32Field(value: &self.batchNumber) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.code != 0 {
+      try visitor.visitSingularInt32Field(value: self.code, fieldNumber: 1)
+    }
+    if !self.domain.isEmpty {
+      try visitor.visitSingularStringField(value: self.domain, fieldNumber: 2)
+    }
+    if !self.description_p.isEmpty {
+      try visitor.visitSingularStringField(value: self.description_p, fieldNumber: 3)
+    }
+    if self.batchNumber != 0 {
+      try visitor.visitSingularInt32Field(value: self.batchNumber, fieldNumber: 4)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Event_IOSError, rhs: Event_IOSError) -> Bool {
+    if lhs.code != rhs.code {return false}
+    if lhs.domain != rhs.domain {return false}
+    if lhs.description_p != rhs.description_p {return false}
+    if lhs.batchNumber != rhs.batchNumber {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Event_ErrorHistory: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ErrorHistory"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "ios_errors"),
+    2: .standard(proto: "total_errors"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.iosErrors) }()
+      case 2: try { try decoder.decodeSingularInt32Field(value: &self.totalErrors) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.iosErrors.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.iosErrors, fieldNumber: 1)
+    }
+    if self.totalErrors != 0 {
+      try visitor.visitSingularInt32Field(value: self.totalErrors, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Event_ErrorHistory, rhs: Event_ErrorHistory) -> Bool {
+    if lhs.iosErrors != rhs.iosErrors {return false}
+    if lhs.totalErrors != rhs.totalErrors {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Event_AncestorIdHistoryItem: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".AncestorIdHistoryItem"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "ancestor_id"),
+    2: .standard(proto: "user_event"),
+    3: .standard(proto: "session_id_from_user_event"),
+    4: .standard(proto: "view_event"),
+    5: .standard(proto: "batch_number"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.ancestorID) }()
+      case 2: try {
+        var v: Event_User?
+        if let current = self.loggedEvent {
+          try decoder.handleConflictingOneOf()
+          if case .userEvent(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.loggedEvent = .userEvent(v)}
+      }()
+      case 3: try {
+        if self.loggedEvent != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.loggedEvent = .sessionIDFromUserEvent(v)}
+      }()
+      case 4: try {
+        var v: Event_View?
+        if let current = self.loggedEvent {
+          try decoder.handleConflictingOneOf()
+          if case .viewEvent(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.loggedEvent = .viewEvent(v)}
+      }()
+      case 5: try { try decoder.decodeSingularInt32Field(value: &self.batchNumber) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.ancestorID.isEmpty {
+      try visitor.visitSingularStringField(value: self.ancestorID, fieldNumber: 1)
+    }
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every case branch when no optimizations are
+    // enabled. https://github.com/apple/swift-protobuf/issues/1034
+    switch self.loggedEvent {
+    case .userEvent?: try {
+      guard case .userEvent(let v)? = self.loggedEvent else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    }()
+    case .sessionIDFromUserEvent?: try {
+      guard case .sessionIDFromUserEvent(let v)? = self.loggedEvent else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+    }()
+    case .viewEvent?: try {
+      guard case .viewEvent(let v)? = self.loggedEvent else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    }()
+    case nil: break
+    }
+    if self.batchNumber != 0 {
+      try visitor.visitSingularInt32Field(value: self.batchNumber, fieldNumber: 5)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Event_AncestorIdHistoryItem, rhs: Event_AncestorIdHistoryItem) -> Bool {
+    if lhs.ancestorID != rhs.ancestorID {return false}
+    if lhs.loggedEvent != rhs.loggedEvent {return false}
+    if lhs.batchNumber != rhs.batchNumber {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Event_AncestorIdHistory: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".AncestorIdHistory"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "ancestor_id_history"),
+    2: .standard(proto: "total_log_user_ids_logged"),
+    3: .standard(proto: "session_id_history"),
+    4: .standard(proto: "total_session_ids_logged"),
+    5: .standard(proto: "view_id_history"),
+    6: .standard(proto: "total_view_ids_logged"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.ancestorIDHistory) }()
+      case 2: try { try decoder.decodeSingularInt32Field(value: &self.totalLogUserIdsLogged) }()
+      case 3: try { try decoder.decodeRepeatedMessageField(value: &self.sessionIDHistory) }()
+      case 4: try { try decoder.decodeSingularInt32Field(value: &self.totalSessionIdsLogged) }()
+      case 5: try { try decoder.decodeRepeatedMessageField(value: &self.viewIDHistory) }()
+      case 6: try { try decoder.decodeSingularInt32Field(value: &self.totalViewIdsLogged) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.ancestorIDHistory.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.ancestorIDHistory, fieldNumber: 1)
+    }
+    if self.totalLogUserIdsLogged != 0 {
+      try visitor.visitSingularInt32Field(value: self.totalLogUserIdsLogged, fieldNumber: 2)
+    }
+    if !self.sessionIDHistory.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.sessionIDHistory, fieldNumber: 3)
+    }
+    if self.totalSessionIdsLogged != 0 {
+      try visitor.visitSingularInt32Field(value: self.totalSessionIdsLogged, fieldNumber: 4)
+    }
+    if !self.viewIDHistory.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.viewIDHistory, fieldNumber: 5)
+    }
+    if self.totalViewIdsLogged != 0 {
+      try visitor.visitSingularInt32Field(value: self.totalViewIdsLogged, fieldNumber: 6)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Event_AncestorIdHistory, rhs: Event_AncestorIdHistory) -> Bool {
+    if lhs.ancestorIDHistory != rhs.ancestorIDHistory {return false}
+    if lhs.totalLogUserIdsLogged != rhs.totalLogUserIdsLogged {return false}
+    if lhs.sessionIDHistory != rhs.sessionIDHistory {return false}
+    if lhs.totalSessionIdsLogged != rhs.totalSessionIdsLogged {return false}
+    if lhs.viewIDHistory != rhs.viewIDHistory {return false}
+    if lhs.totalViewIdsLogged != rhs.totalViewIdsLogged {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Event_MobileDiagnostics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".MobileDiagnostics"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "platform_id"),
+    2: .standard(proto: "user_info"),
+    3: .same(proto: "timing"),
+    4: .standard(proto: "client_info"),
+    5: .standard(proto: "device_identifier"),
+    6: .standard(proto: "client_version"),
+    7: .standard(proto: "promoted_library_version"),
+    8: .standard(proto: "batches_attempted"),
+    9: .standard(proto: "batches_sent_successfully"),
+    10: .standard(proto: "batches_with_errors"),
+    11: .standard(proto: "error_history"),
+    12: .standard(proto: "ancestor_id_history"),
+  ]
+
+  fileprivate class _StorageClass {
+    var _platformID: UInt64 = 0
+    var _userInfo: Common_UserInfo? = nil
+    var _timing: Common_Timing? = nil
+    var _clientInfo: Common_ClientInfo? = nil
+    var _deviceIdentifier: String = String()
+    var _clientVersion: String = String()
+    var _promotedLibraryVersion: String = String()
+    var _batchesAttempted: Int32 = 0
+    var _batchesSentSuccessfully: Int32 = 0
+    var _batchesWithErrors: Int32 = 0
+    var _errorHistory: Event_ErrorHistory? = nil
+    var _ancestorIDHistory: Event_AncestorIdHistory? = nil
+
+    static let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _platformID = source._platformID
+      _userInfo = source._userInfo
+      _timing = source._timing
+      _clientInfo = source._clientInfo
+      _deviceIdentifier = source._deviceIdentifier
+      _clientVersion = source._clientVersion
+      _promotedLibraryVersion = source._promotedLibraryVersion
+      _batchesAttempted = source._batchesAttempted
+      _batchesSentSuccessfully = source._batchesSentSuccessfully
+      _batchesWithErrors = source._batchesWithErrors
+      _errorHistory = source._errorHistory
+      _ancestorIDHistory = source._ancestorIDHistory
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        // The use of inline closures is to circumvent an issue where the compiler
+        // allocates stack space for every case branch when no optimizations are
+        // enabled. https://github.com/apple/swift-protobuf/issues/1034
+        switch fieldNumber {
+        case 1: try { try decoder.decodeSingularUInt64Field(value: &_storage._platformID) }()
+        case 2: try { try decoder.decodeSingularMessageField(value: &_storage._userInfo) }()
+        case 3: try { try decoder.decodeSingularMessageField(value: &_storage._timing) }()
+        case 4: try { try decoder.decodeSingularMessageField(value: &_storage._clientInfo) }()
+        case 5: try { try decoder.decodeSingularStringField(value: &_storage._deviceIdentifier) }()
+        case 6: try { try decoder.decodeSingularStringField(value: &_storage._clientVersion) }()
+        case 7: try { try decoder.decodeSingularStringField(value: &_storage._promotedLibraryVersion) }()
+        case 8: try { try decoder.decodeSingularInt32Field(value: &_storage._batchesAttempted) }()
+        case 9: try { try decoder.decodeSingularInt32Field(value: &_storage._batchesSentSuccessfully) }()
+        case 10: try { try decoder.decodeSingularInt32Field(value: &_storage._batchesWithErrors) }()
+        case 11: try { try decoder.decodeSingularMessageField(value: &_storage._errorHistory) }()
+        case 12: try { try decoder.decodeSingularMessageField(value: &_storage._ancestorIDHistory) }()
+        default: break
+        }
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if _storage._platformID != 0 {
+        try visitor.visitSingularUInt64Field(value: _storage._platformID, fieldNumber: 1)
+      }
+      if let v = _storage._userInfo {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
+      if let v = _storage._timing {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
+      if let v = _storage._clientInfo {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+      }
+      if !_storage._deviceIdentifier.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._deviceIdentifier, fieldNumber: 5)
+      }
+      if !_storage._clientVersion.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._clientVersion, fieldNumber: 6)
+      }
+      if !_storage._promotedLibraryVersion.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._promotedLibraryVersion, fieldNumber: 7)
+      }
+      if _storage._batchesAttempted != 0 {
+        try visitor.visitSingularInt32Field(value: _storage._batchesAttempted, fieldNumber: 8)
+      }
+      if _storage._batchesSentSuccessfully != 0 {
+        try visitor.visitSingularInt32Field(value: _storage._batchesSentSuccessfully, fieldNumber: 9)
+      }
+      if _storage._batchesWithErrors != 0 {
+        try visitor.visitSingularInt32Field(value: _storage._batchesWithErrors, fieldNumber: 10)
+      }
+      if let v = _storage._errorHistory {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
+      }
+      if let v = _storage._ancestorIDHistory {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
+      }
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Event_MobileDiagnostics, rhs: Event_MobileDiagnostics) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._platformID != rhs_storage._platformID {return false}
+        if _storage._userInfo != rhs_storage._userInfo {return false}
+        if _storage._timing != rhs_storage._timing {return false}
+        if _storage._clientInfo != rhs_storage._clientInfo {return false}
+        if _storage._deviceIdentifier != rhs_storage._deviceIdentifier {return false}
+        if _storage._clientVersion != rhs_storage._clientVersion {return false}
+        if _storage._promotedLibraryVersion != rhs_storage._promotedLibraryVersion {return false}
+        if _storage._batchesAttempted != rhs_storage._batchesAttempted {return false}
+        if _storage._batchesSentSuccessfully != rhs_storage._batchesSentSuccessfully {return false}
+        if _storage._batchesWithErrors != rhs_storage._batchesWithErrors {return false}
+        if _storage._errorHistory != rhs_storage._errorHistory {return false}
+        if _storage._ancestorIDHistory != rhs_storage._ancestorIDHistory {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
 extension Event_LogRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".LogRequest"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "platform_id"),
     2: .standard(proto: "user_info"),
     3: .same(proto: "timing"),
+    4: .standard(proto: "client_info"),
     7: .same(proto: "user"),
     8: .standard(proto: "cohort_membership"),
     11: .same(proto: "view"),
@@ -2361,6 +3179,7 @@ extension Event_LogRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
     13: .same(proto: "insertion"),
     14: .same(proto: "impression"),
     15: .same(proto: "action"),
+    17: .standard(proto: "mobile_diagnostics"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -2372,6 +3191,7 @@ extension Event_LogRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
       case 1: try { try decoder.decodeSingularUInt64Field(value: &self.platformID) }()
       case 2: try { try decoder.decodeSingularMessageField(value: &self._userInfo) }()
       case 3: try { try decoder.decodeSingularMessageField(value: &self._timing) }()
+      case 4: try { try decoder.decodeSingularMessageField(value: &self._clientInfo) }()
       case 7: try { try decoder.decodeRepeatedMessageField(value: &self.user) }()
       case 8: try { try decoder.decodeRepeatedMessageField(value: &self.cohortMembership) }()
       case 11: try { try decoder.decodeRepeatedMessageField(value: &self.view) }()
@@ -2379,6 +3199,7 @@ extension Event_LogRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
       case 13: try { try decoder.decodeRepeatedMessageField(value: &self.insertion) }()
       case 14: try { try decoder.decodeRepeatedMessageField(value: &self.impression) }()
       case 15: try { try decoder.decodeRepeatedMessageField(value: &self.action) }()
+      case 17: try { try decoder.decodeSingularMessageField(value: &self._mobileDiagnostics) }()
       default: break
       }
     }
@@ -2393,6 +3214,9 @@ extension Event_LogRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
     }
     if let v = self._timing {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }
+    if let v = self._clientInfo {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
     }
     if !self.user.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.user, fieldNumber: 7)
@@ -2415,6 +3239,9 @@ extension Event_LogRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
     if !self.action.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.action, fieldNumber: 15)
     }
+    if let v = self._mobileDiagnostics {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -2422,6 +3249,7 @@ extension Event_LogRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
     if lhs.platformID != rhs.platformID {return false}
     if lhs._userInfo != rhs._userInfo {return false}
     if lhs._timing != rhs._timing {return false}
+    if lhs._clientInfo != rhs._clientInfo {return false}
     if lhs.user != rhs.user {return false}
     if lhs.cohortMembership != rhs.cohortMembership {return false}
     if lhs.view != rhs.view {return false}
@@ -2429,6 +3257,7 @@ extension Event_LogRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
     if lhs.insertion != rhs.insertion {return false}
     if lhs.impression != rhs.impression {return false}
     if lhs.action != rhs.action {return false}
+    if lhs._mobileDiagnostics != rhs._mobileDiagnostics {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/PromotedCore/ScrollTracker.swift
+++ b/Sources/PromotedCore/ScrollTracker.swift
@@ -76,7 +76,7 @@ import UIKit
  
  ## React Native
  
- Use the `useImpressionLogger()` hook for accurate tracking in `FlatList`s
+ Use the `useImpressionTracker()` hook for accurate tracking in `FlatList`s
  and `SectionList`s. If using some other kind of scroll view, set the scroll
  view's viewport manually through the `viewport` property when the scroll
  view updates.
@@ -92,7 +92,7 @@ public final class ScrollTracker: NSObject {
   private unowned let metricsLogger: MetricsLogger
   private unowned let monitor: OperationMonitor
 
-  private let impressionLogger: ImpressionLogger
+  private let impressionTracker: ImpressionTracker
   private var content: [(CGRect, Content)]
   private var timer: ScheduledTimer?
 
@@ -133,7 +133,7 @@ public final class ScrollTracker: NSObject {
     self.updateFrequency = clientConfig.scrollTrackerUpdateFrequency
     self.metricsLogger = metricsLogger
     self.monitor = deps.operationMonitor
-    self.impressionLogger = ImpressionLogger(metricsLogger: metricsLogger, deps: deps)
+    self.impressionTracker = ImpressionTracker(metricsLogger: metricsLogger, deps: deps)
     self.content = []
     self.timer = nil
     self.viewport = CGRect.zero
@@ -148,7 +148,7 @@ public final class ScrollTracker: NSObject {
   }
 
   @objc public func scrollViewDidHideAllContent() {
-    impressionLogger.collectionViewDidHideAllContent()
+    impressionTracker.collectionViewDidHideAllContent()
   }
 
   private func maybeScheduleUpdateVisibilityTimer() {
@@ -171,7 +171,7 @@ public final class ScrollTracker: NSObject {
           visibleContent.append(content)
         }
       }
-      impressionLogger.collectionViewDidChangeVisibleContent(visibleContent)
+      impressionTracker.collectionViewDidChangeVisibleContent(visibleContent)
     }
   }
 }

--- a/Tests/PromotedCoreTests/ImpressionTrackerTests.swift
+++ b/Tests/PromotedCoreTests/ImpressionTrackerTests.swift
@@ -36,9 +36,10 @@ final class ImpressionTrackerTests: ModuleTestCase {
   
   private func impression(_ contentID: String,
                           _ startTime: TimeInterval,
-                          _ endTime: TimeInterval? = nil) -> Impression {
+                          _ endTime: TimeInterval? = nil,
+                          _ sourceType: ImpressionSourceType = .unknown) -> Impression {
     let content = Content(contentID: contentID)
-    return ImpressionTracker.Impression(content: content, startTime: startTime, endTime: endTime)
+    return ImpressionTracker.Impression(content: content, startTime: startTime, endTime: endTime, sourceType: sourceType)
   }
 
   /** Asserts that list contents are equal regardless of order. */

--- a/Tests/PromotedCoreTests/ImpressionTrackerTests.swift
+++ b/Tests/PromotedCoreTests/ImpressionTrackerTests.swift
@@ -100,7 +100,8 @@ final class ImpressionTrackerTests: ModuleTestCase {
   }
 
   func testStartImpressionsLoggedEvents() {
-    impressionTracker = impressionTracker.with(sourceType: .delivery)
+    impressionTracker = ImpressionTracker(metricsLogger: metricsLogger, deps: module)
+      .with(sourceType: .delivery)
     clock.advance(to: 123)
     impressionTracker.collectionViewWillDisplay(content: content("jeff"))
     clock.now = 500


### PR DESCRIPTION
## `ImpressionSourceType` changes
- Add support for `ImpressionSourceType` enum in impression logging classes.
- Regenerate Swift protos with latest schema that supports this enum.
- Plumb through support for this enum in `MetricsLogger`.
- Add `ImpressionConfig` protocol to provide configuration interface to `ImpressionTracker` and `ScrollTracker`.
- Add test that this value gets logged in protos.

## Rename `ImpressionLogger` --> `ImpressionTracker`
- Rename the class and related methods/variables to better conform to `ViewTracker` and `ScrollTracker` naming.
- Move impression tracking classes into their own directory.

## Cleanup
- Change a few code blocks in comments to better work with Xcode 13 beta.
- Divide `ImpressionTracker` and `MetricsLogger+Helpers` into more extensions to group class functionality.