### PR TITLE
Automatically flush logger when resigning foreground

### DIFF
--- a/Sources/PromotedCore/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig.swift
@@ -86,7 +86,7 @@ public final class ClientConfig: NSObject {
   }
 
   /// Whether to automatically flush all pending log messages
-  /// when the application enters background.
+  /// when the application resigns active.
   public var flushLoggingOnResignActive: Bool = true
 
   /// Ratio of the view that must be visible to log impression

--- a/Sources/PromotedCore/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig.swift
@@ -84,7 +84,11 @@ public final class ClientConfig: NSObject {
   public var loggingFlushInterval: TimeInterval = 10.0 {
     didSet { bound(&loggingFlushInterval, min: 1.0, max: 300.0) }
   }
-  
+
+  /// Whether to automatically flush all pending log messages
+  /// when the application enters background.
+  public var flushLoggingOnResignActive: Bool = true
+
   /// Ratio of the view that must be visible to log impression
   /// with `ScrollTracker`.
   public var scrollTrackerVisibilityThreshold: Float = 0.5 {


### PR DESCRIPTION
This will cause us to call `metricsLogger.flush()` automatically when the app resigns foreground (ie. the user switches away from it). Before, clients had to do this manually.
- Listen for a notification when resigning foreground and flush when this notification occurs.
- Add a `ClientConfig` setting for this behavior.