### PR TITLE
Make `ClientConfig` a struct so we pass it by value

### DIFF
--- a/Sources/PromotedCore/ClientConfig/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/ClientConfig.swift
@@ -374,12 +374,12 @@ extension ClientConfig {
 
   /// Validate enums and set them to appropriate defaults.
   /// Deserialization might produce invalid enum values.
-  private func validateEnum<T: ConfigEnum & RawRepresentable>(
+  private func validateEnum<T: ConfigEnum>(
     _ value: inout T,
     defaultValue: T,
     propertyName: String = #function
-  ) where T.RawValue == Int {
-    if !T.allCases.contains(value) || value.rawValue == 0 {
+  ) {
+    if !T.allCases.contains(value) || value == T.unknownValue {
       assert(
         !assertInValidation,
         "\(propertyName): unknown case for enum " +

--- a/Sources/PromotedCore/ClientConfig/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/ClientConfig.swift
@@ -420,7 +420,7 @@ public func < <T: RawRepresentable>(
 }
 
 public extension _ConfigEnum {
-  init?(name: String) {
+  init?(_ name: String) {
     for value in Self.allCases {
       if value.description == name {
         self = value

--- a/Sources/PromotedCore/ClientConfig/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/ClientConfig.swift
@@ -211,60 +211,31 @@ public struct ClientConfig: Codable {
 
 public extension ClientConfig {
 
-  typealias ConfigKeyPath<Value> = WritableKeyPath<ClientConfig, Value>
+  typealias AnyConfigKeyPath = PartialKeyPath<ClientConfig>
 
-  static let boolKeyPaths: [String: ConfigKeyPath<Bool>] = [
-    "loggingEnabled": \.loggingEnabled,
-    "flushLoggingOnResignActive": \.flushLoggingOnResignActive,
-    "diagnosticsIncludeBatchSummaries": \.diagnosticsIncludeBatchSummaries,
+  static let allKeyPaths: [String: AnyConfigKeyPath] = [
+    "apiKeyHTTPHeaderField": \ClientConfig.apiKeyHTTPHeaderField,
+    "devMetricsLoggingAPIKey": \ClientConfig.devMetricsLoggingAPIKey,
+    "devMetricsLoggingURL": \ClientConfig.devMetricsLoggingURL,
     "diagnosticsIncludeAncestorIDHistory":
-      \.diagnosticsIncludeAncestorIDHistory
+      \ClientConfig.diagnosticsIncludeAncestorIDHistory,
+    "diagnosticsIncludeBatchSummaries": \ClientConfig.diagnosticsIncludeBatchSummaries,
+    "flushLoggingOnResignActive": \ClientConfig.flushLoggingOnResignActive,
+    "loggingEnabled": \ClientConfig.loggingEnabled,
+    "loggingFlushInterval": \ClientConfig.loggingFlushInterval,
+    "metricsLoggingAPIKey": \ClientConfig.metricsLoggingAPIKey,
+    "metricsLoggingWireFormat": \ClientConfig.metricsLoggingWireFormat,
+    "metricsLoggingURL": \ClientConfig.metricsLoggingURL,
+    "osLogLevel": \ClientConfig.osLogLevel,
+    "scrollTrackerDurationThreshold": \ClientConfig.scrollTrackerDurationThreshold,
+    "scrollTrackerUpdateFrequency": \ClientConfig.scrollTrackerUpdateFrequency,
+    "scrollTrackerVisibilityThreshold": \ClientConfig.scrollTrackerVisibilityThreshold,
+    "xrayLevel": \ClientConfig.xrayLevel,
   ]
 
-  static let stringKeyPaths: [String: ConfigKeyPath<String>] = [
-    "metricsLoggingURL": \.metricsLoggingURL,
-    "devMetricsLoggingURL": \.devMetricsLoggingURL,
-    "metricsLoggingAPIKey": \.metricsLoggingAPIKey,
-    "devMetricsLoggingAPIKey": \.devMetricsLoggingAPIKey,
-    "apiKeyHTTPHeaderField": \.apiKeyHTTPHeaderField
-  ]
+  typealias ConfigKeyPath<Value> = KeyPath<ClientConfig, Value>
 
-  static let timeIntervalKeyPaths: [String: ConfigKeyPath<TimeInterval>] = [
-    "loggingFlushInterval": \.loggingFlushInterval,
-    "scrollTrackerDurationThreshold": \.scrollTrackerDurationThreshold,
-    "scrollTrackerUpdateFrequency": \.scrollTrackerUpdateFrequency
-  ]
-
-  static let floatKeyPaths: [String: ConfigKeyPath<Float>] = [
-    "scrollTrackerVisibilityThreshold": \.scrollTrackerVisibilityThreshold
-  ]
-
-  static let metricsLoggingWireFormatKeyPaths:
-    [String: ConfigKeyPath<MetricsLoggingWireFormat>] =
-  [
-    "metricsLoggingWireFormat": \.metricsLoggingWireFormat
-  ]
-
-  static let xrayLevelKeyPaths: [String: ConfigKeyPath<XrayLevel>] = [
-    "xrayLevel": \.xrayLevel
-  ]
-
-  static let osLogLevelKeyPaths: [String: ConfigKeyPath<OSLogLevel>] = [
-    "osLogLevel": \.osLogLevel
-  ]
-
-  static let allKeyPaths: [String: Any] = {
-    var result: [String: Any] = [:]
-    boolKeyPaths.forEach { result[$0] = $1 }
-    stringKeyPaths.forEach { result[$0] = $1 }
-    timeIntervalKeyPaths.forEach { result[$0] = $1 }
-    floatKeyPaths.forEach { result[$0] = $1 }
-    metricsLoggingWireFormatKeyPaths.forEach { result[$0] = $1 }
-    xrayLevelKeyPaths.forEach { result[$0] = $1 }
-    osLogLevelKeyPaths.forEach { result[$0] = $1 }
-    return result
-  } ()
-
+  /// Returns value for named property.
   func value(forName name: String) -> Any? {
     guard let keyPath = Self.allKeyPaths[name] else { return nil }
     switch keyPath {
@@ -283,43 +254,60 @@ public extension ClientConfig {
     case let k as ConfigKeyPath<OSLogLevel>:
       return self[keyPath: k]
     default:
-      return nil
+      break
     }
+    assert(!assertInValidation, "Unknown key: \(name)")
+    return nil
   }
 
+  typealias WritableConfigKeyPath<Value> = WritableKeyPath<ClientConfig, Value>
+
+  /// Sets value for named property.
   mutating func setValue(_ value: Any, forName name: String) {
+    guard let keyPath = Self.allKeyPaths[name] else { return }
     switch value {
     case let intValue as Bool:
-      if let k = Self.boolKeyPaths[name] {
+      if let k = keyPath as? WritableConfigKeyPath<Bool> {
         self[keyPath: k] = intValue
+        return
       }
     case let stringValue as String:
-      if let k = Self.stringKeyPaths[name] {
+      if let k = keyPath as? WritableConfigKeyPath<String> {
         self[keyPath: k] = stringValue
+        return
       }
     case let timeValue as TimeInterval:
-      if let k = Self.timeIntervalKeyPaths[name] {
+      if let k = keyPath as? WritableConfigKeyPath<TimeInterval> {
         self[keyPath: k] = timeValue
+        return
       }
     case let floatValue as Float:
-      if let k = Self.floatKeyPaths[name] {
+      if let k = keyPath as? WritableConfigKeyPath<Float> {
         self[keyPath: k] = floatValue
+        return
       }
     case let m as MetricsLoggingWireFormat:
-      if let k = Self.metricsLoggingWireFormatKeyPaths[name] {
+      if let k = keyPath as? WritableConfigKeyPath<MetricsLoggingWireFormat> {
         self[keyPath: k] = m
+        return
       }
     case let x as XrayLevel:
-      if let k = Self.xrayLevelKeyPaths[name] {
+      if let k = keyPath as? WritableConfigKeyPath<XrayLevel> {
         self[keyPath: k] = x
+        return
       }
     case let o as OSLogLevel:
-      if let k = Self.osLogLevelKeyPaths[name] {
+      if let k = keyPath as? WritableConfigKeyPath<OSLogLevel> {
         self[keyPath: k] = o
+        return
       }
     default:
       break
     }
+    assert(
+      !assertInValidation,
+      "Could not set value \(String(describing: value)) for key \(name)"
+    )
   }
 }
 

--- a/Sources/PromotedCore/ClientConfig/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/ClientConfig.swift
@@ -251,15 +251,17 @@ public extension ClientConfig {
     "scrollTrackerVisibilityThreshold": \.scrollTrackerVisibilityThreshold
   ]
 
-  static let metricsLoggingWireFormatKeyPaths: [String: ConfigKeyPath<ClientConfig.MetricsLoggingWireFormat>] = [
+  static let metricsLoggingWireFormatKeyPaths:
+    [String: ConfigKeyPath<MetricsLoggingWireFormat>] =
+  [
     "metricsLoggingWireFormat": \.metricsLoggingWireFormat
   ]
 
-  static let xrayLevelKeyPaths: [String: ConfigKeyPath<ClientConfig.XrayLevel>] = [
+  static let xrayLevelKeyPaths: [String: ConfigKeyPath<XrayLevel>] = [
     "xrayLevel": \.xrayLevel
   ]
 
-  static let osLogLevelKeyPaths: [String: ConfigKeyPath<ClientConfig.OSLogLevel>] = [
+  static let osLogLevelKeyPaths: [String: ConfigKeyPath<OSLogLevel>] = [
     "osLogLevel": \.osLogLevel
   ]
 
@@ -286,11 +288,11 @@ public extension ClientConfig {
       return self[keyPath: k]
     case let k as ConfigKeyPath<Float>:
       return self[keyPath: k]
-    case let k as ConfigKeyPath<ClientConfig.MetricsLoggingWireFormat>:
+    case let k as ConfigKeyPath<MetricsLoggingWireFormat>:
       return self[keyPath: k]
-    case let k as ConfigKeyPath<ClientConfig.XrayLevel>:
+    case let k as ConfigKeyPath<XrayLevel>:
       return self[keyPath: k]
-    case let k as ConfigKeyPath<ClientConfig.OSLogLevel>:
+    case let k as ConfigKeyPath<OSLogLevel>:
       return self[keyPath: k]
     default:
       return nil
@@ -315,15 +317,15 @@ public extension ClientConfig {
       if let k = Self.floatKeyPaths[name] {
         self[keyPath: k] = floatValue
       }
-    case let m as ClientConfig.MetricsLoggingWireFormat:
+    case let m as MetricsLoggingWireFormat:
       if let k = Self.metricsLoggingWireFormatKeyPaths[name] {
         self[keyPath: k] = m
       }
-    case let x as ClientConfig.XrayLevel:
+    case let x as XrayLevel:
       if let k = Self.xrayLevelKeyPaths[name] {
         self[keyPath: k] = x
       }
-    case let o as ClientConfig.OSLogLevel:
+    case let o as OSLogLevel:
       if let k = Self.osLogLevelKeyPaths[name] {
         self[keyPath: k] = o
       }
@@ -355,13 +357,17 @@ extension ClientConfig {
     propertyName: String = #function
   ) {
     if let min = min {
-      assert(!assertInValidation || value >= min,
-             "\(propertyName): min value \(min) (> \(value))")
+      assert(
+        !assertInValidation || value >= min,
+        "\(propertyName): min value \(min) (> \(value))"
+      )
       value = Swift.max(min, value)
     }
     if let max = max {
-      assert(!assertInValidation || value <= max,
-             "\(propertyName): max value \(max) (< \(value))")
+      assert(
+        !assertInValidation || value <= max,
+        "\(propertyName): max value \(max) (< \(value))"
+      )
       value = Swift.min(max, value)
     }
   }

--- a/Sources/PromotedCore/ClientConfig/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/ClientConfig.swift
@@ -323,9 +323,9 @@ public extension ClientConfig {
       return
     }
     switch value {
-    case let intValue as Bool:
+    case let boolValue as Bool:
       if let k = keyPath as? WritableConfigKeyPath<Bool> {
-        self[keyPath: k] = intValue
+        self[keyPath: k] = boolValue
         return
       }
     case let stringValue as String:

--- a/Sources/PromotedCore/ClientConfig/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/ClientConfig.swift
@@ -1,9 +1,5 @@
 import Foundation
 
-/// Use `ClientConfig.ConfigEnum` instead.
-public protocol _ConfigEnum:
-  CaseIterable, Codable, CustomStringConvertible, Equatable {}
-
 // MARK: - ClientConfig properties
 /**
  Configuration for Promoted logging library internal behavior.
@@ -93,358 +89,63 @@ public protocol _ConfigEnum:
  values don't cause unreasonable behavior during runtime. See
  `bound` and `validateEnum`.
  */
-public struct ClientConfig: Codable {
-  /// Enumeration value in config.
-  public typealias ConfigEnum = _ConfigEnum
+@dynamicMemberLookup
+public struct ClientConfig {
 
-  /// Controls whether log messages are sent over the network.
-  /// Setting this property to `false` will prevent log messages
-  /// from being sent, but these messages may still be collected
-  /// at runtime and stored in memory.
-  public var loggingEnabled: Bool = true
+  public typealias MetricsLoggingWireFormat =
+    _ObjCClientConfig.MetricsLoggingWireFormat
+  public typealias XrayLevel = _ObjCClientConfig.XrayLevel
+  public typealias OSLogLevel = _ObjCClientConfig.OSLogLevel
 
-  /// URL for logging endpoint as used by `NetworkConnection`.
-  /// Implementations of `NetworkConnection` from Promoted will
-  /// use this field. Custom implementations of `NetworkConnection`
-  /// may vary in behavior.
-  public var metricsLoggingURL: String = ""
+  private var config: _ObjCClientConfig = _ObjCClientConfig()
 
-  /// URL for logging endpoint as used by `NetworkConnection`
-  /// for debug/staging purposes. Used when the app is running
-  /// in debug configuration.
-  ///
-  /// If this property is not set, then debug builds will use
-  /// `metricsLoggingURL` for logging endpoint URL.
-  ///
-  /// Implementations of `NetworkConnection` from Promoted will
-  /// use this field. Custom implementations of `NetworkConnection`
-  /// may vary in behavior.
-  public var devMetricsLoggingURL: String = ""
-  
-  /// API key for logging endpoint.
-  /// Implementations of `NetworkConnection` from Promoted will
-  /// use this field. Custom implementations of `NetworkConnection`
-  /// may vary in behavior.
-  public var metricsLoggingAPIKey: String = ""
-  
-  /// API key for logging endpoint for debug/staging purposes.
-  /// Used when the app is running in debug configuration.
-  ///
-  /// If this property is not set, then debug builds will use
-  /// `metricsLoggingAPIKey` for logging endpoint API key.
-  ///
-  /// Implementations of `NetworkConnection` from Promoted will
-  /// use this field. Custom implementations of `NetworkConnection`
-  /// may vary in behavior.
-  public var devMetricsLoggingAPIKey: String = ""
-
-  /// HTTP header field for API key.
-  public var apiKeyHTTPHeaderField: String = "x-api-key"
-
-  /// Format to use when sending protobuf log messages over network.
-  @objc(PROMetricsLoggingWireFormat)
-  public enum MetricsLoggingWireFormat: Int, ConfigEnum {
-    /// https://developers.google.com/protocol-buffers/docs/proto3#json
-    case json = 1
-    /// https://developers.google.com/protocol-buffers/docs/encoding
-    case binary = 2
-  }
-  /// Format to use when sending protobuf log messages over network.
-  public var metricsLoggingWireFormat: MetricsLoggingWireFormat = .binary {
-    didSet { validateEnum(&metricsLoggingWireFormat, defaultValue: .binary) }
-  }
-
-  /// Interval at which log messages are sent over the network.
-  /// Setting this to lower values will increase the frequency
-  /// at which log messages are sent.
-  public var loggingFlushInterval: TimeInterval = 10.0 {
-    didSet { bound(&loggingFlushInterval, min: 1.0, max: 300.0) }
-  }
-
-  /// Whether to automatically flush all pending log messages
-  /// when the application resigns active.
-  public var flushLoggingOnResignActive: Bool = true
-
-  /// Ratio of the view that must be visible to log impression
-  /// with `ScrollTracker`.
-  public var scrollTrackerVisibilityThreshold: Float = 0.5 {
-    didSet { bound(&scrollTrackerVisibilityThreshold, min: 0.0, max: 1.0) }
-  }
-
-  /// Time on screen required to log impression with `ScrollTracker`.
-  public var scrollTrackerDurationThreshold: TimeInterval = 1.0 {
-    didSet { bound(&scrollTrackerDurationThreshold, min: 0.0) }
-  }
-
-  /// Frequency at which `ScrollTracker` calculates impressions.
-  /// Setting this to lower values will increase the amount of
-  /// processing that `ScrollTracker` performs.
-  public var scrollTrackerUpdateFrequency: TimeInterval = 0.5 {
-    didSet { bound(&scrollTrackerUpdateFrequency, min: 0.1, max: 30.0) }
-  }
-
-  @objc(PROXrayLevel)
-  public enum XrayLevel: Int, Comparable, ConfigEnum {
-    // Don't gather any Xray stats data at all.
-    case none = 1
-    // Gather overall counts for the session for each batch.
-    // ie. batches: 40, batches sent successfully: 39, errors: 1
-    case batchSummaries = 2
-    // Gather stats and logged messages for each call made
-    // to the metrics library.
-    case callDetails = 3
-    // Gathers stats and logged messages for each call made
-    // to the metrics library, as well as stack traces where the
-    // calls were made.
-    case callDetailsAndStackTraces = 4
-  }
-  /// Level of Xray profiling for this session.
-  /// Setting this to `.none` also forces
-  /// `diagnosticsIncludeBatchSummaries` to be false.
-  public var xrayLevel: XrayLevel = .none {
-    didSet {
-      validateEnum(&xrayLevel, defaultValue: .none)
-      if xrayLevel == .none && diagnosticsIncludeBatchSummaries {
-        diagnosticsIncludeBatchSummaries = false
+  public subscript<T>(
+    dynamicMember keyPath: WritableKeyPath<_ObjCClientConfig, T>
+  ) -> T {
+    get { config[keyPath: keyPath] }
+    set {
+      if !isKnownUniquelyReferenced(&config) {
+        config = _ObjCClientConfig(config)
       }
+      config[keyPath: keyPath] = newValue
     }
   }
 
-  @objc(PROOSLogLevel)
-  public enum OSLogLevel: Int, Comparable, ConfigEnum {
-    /// No logging for anything.
-    case none = 1
-    /// Logging only for errors.
-    case error = 2
-    /// Logging for errors and warnings.
-    case warning = 3
-    /// Logging for info messages (and above).
-    case info = 4
-    /// Logging for debug messages (and above).
-    case debug = 5
-  }
-  /// Whether to use OSLog (console logging) to output messages.
-  /// OSLog typically incurs minimal overhead and can be useful for
-  /// verifying that logging works from the client side.
-  /// If `xrayEnabled` is also set, then setting `osLogLevel`
-  /// to `info` or higher turns on signposts in Instruments.
-  public var osLogLevel: OSLogLevel = .none {
-    didSet { validateEnum(&osLogLevel, defaultValue: .none) }
+  public func value(forKey key: String) -> Any? {
+    config.value(forKey: key)
   }
 
-  /// Whether mobile diagnostic messages include batch summaries
-  /// from Xray. Setting this to `true` also forces `xrayLevel` to
-  /// be at least `.batchSummaries`.
-  public var diagnosticsIncludeBatchSummaries: Bool = false {
-    didSet {
-      if diagnosticsIncludeBatchSummaries && xrayLevel == .none {
-        xrayLevel = .batchSummaries
-      }
+  public mutating func setValue(_ value: Any?, forKey key: String) {
+    if !isKnownUniquelyReferenced(&config) {
+      config = _ObjCClientConfig(config)
     }
+    config.setValue(value, forKey: key)
   }
 
-  /// Whether mobile diagnostic messages include a history of
-  /// ancestor IDs being set for the session.
-  public var diagnosticsIncludeAncestorIDHistory: Bool = false
+  public init() {}
 
-  var anyDiagnosticsEnabled: Bool {
-    diagnosticsIncludeBatchSummaries ||
-      diagnosticsIncludeAncestorIDHistory
-  }
-
-  private var assertInValidation: Bool = true
-}
-
-// MARK: - Key paths
-
-public extension ClientConfig {
-
-  typealias AnyConfigKeyPath = PartialKeyPath<ClientConfig>
-
-  static let allKeyPaths: [String: AnyConfigKeyPath] = [
-    "apiKeyHTTPHeaderField": \ClientConfig.apiKeyHTTPHeaderField,
-    "devMetricsLoggingAPIKey": \ClientConfig.devMetricsLoggingAPIKey,
-    "devMetricsLoggingURL": \ClientConfig.devMetricsLoggingURL,
-    "diagnosticsIncludeAncestorIDHistory":
-      \ClientConfig.diagnosticsIncludeAncestorIDHistory,
-    "diagnosticsIncludeBatchSummaries":
-      \ClientConfig.diagnosticsIncludeBatchSummaries,
-    "flushLoggingOnResignActive": \ClientConfig.flushLoggingOnResignActive,
-    "loggingEnabled": \ClientConfig.loggingEnabled,
-    "loggingFlushInterval": \ClientConfig.loggingFlushInterval,
-    "metricsLoggingAPIKey": \ClientConfig.metricsLoggingAPIKey,
-    "metricsLoggingWireFormat": \ClientConfig.metricsLoggingWireFormat,
-    "metricsLoggingURL": \ClientConfig.metricsLoggingURL,
-    "osLogLevel": \ClientConfig.osLogLevel,
-    "scrollTrackerDurationThreshold":
-      \ClientConfig.scrollTrackerDurationThreshold,
-    "scrollTrackerUpdateFrequency": \ClientConfig.scrollTrackerUpdateFrequency,
-    "scrollTrackerVisibilityThreshold":
-      \ClientConfig.scrollTrackerVisibilityThreshold,
-    "xrayLevel": \ClientConfig.xrayLevel,
-  ]
-
-  typealias ConfigKeyPath<Value> = KeyPath<ClientConfig, Value>
-
-  /// Returns value for named property.
-  func value(forName name: String) -> Any? {
-    guard let keyPath = Self.allKeyPaths[name] else {
-      assert(!assertInValidation, "Unknown key: \(name)")
-      return nil
-    }
-    switch keyPath {
-    case let k as ConfigKeyPath<Bool>:
-      return self[keyPath: k]
-    case let k as ConfigKeyPath<String>:
-      return self[keyPath: k]
-    case let k as ConfigKeyPath<TimeInterval>:
-      return self[keyPath: k]
-    case let k as ConfigKeyPath<Float>:
-      return self[keyPath: k]
-    case let k as ConfigKeyPath<MetricsLoggingWireFormat>:
-      return self[keyPath: k]
-    case let k as ConfigKeyPath<XrayLevel>:
-      return self[keyPath: k]
-    case let k as ConfigKeyPath<OSLogLevel>:
-      return self[keyPath: k]
-    default:
-      break
-    }
-    assert(!assertInValidation, "Unknown key: \(name)")
-    return nil
-  }
-
-  typealias WritableConfigKeyPath<Value> = WritableKeyPath<ClientConfig, Value>
-
-  /// Sets value for named property.
-  mutating func setValue(_ value: Any, forName name: String) {
-    guard let keyPath = Self.allKeyPaths[name] else {
-      assert(!assertInValidation, "Unknown key: \(name)")
-      return
-    }
-    switch value {
-    case let boolValue as Bool:
-      if let k = keyPath as? WritableConfigKeyPath<Bool> {
-        self[keyPath: k] = boolValue
-        return
-      }
-    case let stringValue as String:
-      if let k = keyPath as? WritableConfigKeyPath<String> {
-        self[keyPath: k] = stringValue
-        return
-      }
-    case let timeValue as TimeInterval:
-      if let k = keyPath as? WritableConfigKeyPath<TimeInterval> {
-        self[keyPath: k] = timeValue
-        return
-      }
-    case let floatValue as Float:
-      if let k = keyPath as? WritableConfigKeyPath<Float> {
-        self[keyPath: k] = floatValue
-        return
-      }
-    case let m as MetricsLoggingWireFormat:
-      if let k = keyPath as? WritableConfigKeyPath<MetricsLoggingWireFormat> {
-        self[keyPath: k] = m
-        return
-      }
-    case let x as XrayLevel:
-      if let k = keyPath as? WritableConfigKeyPath<XrayLevel> {
-        self[keyPath: k] = x
-        return
-      }
-    case let o as OSLogLevel:
-      if let k = keyPath as? WritableConfigKeyPath<OSLogLevel> {
-        self[keyPath: k] = o
-        return
-      }
-    default:
-      break
-    }
-    assert(
-      !assertInValidation,
-      "Could not set value \(String(describing: value)) for key \(name)"
-    )
+  public init(_ config: _ObjCClientConfig) {
+    self.config = config
   }
 }
 
-// MARK: - ObjC compatibility
-public extension ClientConfig {
+// MARK: - Codable
+extension ClientConfig: Codable {}
 
-  init(_ config: _ObjCClientConfig) {
-    let mirror = Mirror(reflecting: config)
-    for child in mirror.children {
-      guard let name = child.label else { continue }
-      setValue(child.value, forName: name)
-    }
-  }
-}
-
-// MARK: - Validation
+// MARK: - Internal
 extension ClientConfig {
 
-  private func bound<T: Comparable>(
-    _ value: inout T,
-    min: T? = nil,
-    max: T? = nil,
-    propertyName: String = #function
-  ) {
-    if let min = min {
-      assert(
-        !assertInValidation || value >= min,
-        "\(propertyName): min value \(min) (> \(value))"
-      )
-      value = Swift.max(min, value)
-    }
-    if let max = max {
-      assert(
-        !assertInValidation || value <= max,
-        "\(propertyName): max value \(max) (< \(value))"
-      )
-      value = Swift.min(max, value)
-    }
-  }
-
-  /// Validate enums and set them to appropriate defaults.
-  /// Deserialization might produce invalid enum values.
-  private func validateEnum<T: ConfigEnum>(
-    _ value: inout T,
-    defaultValue: T,
-    propertyName: String = #function
-  ) {
-    if !T.allCases.contains(value) {
-      assert(
-        !assertInValidation,
-        "\(propertyName): unknown case for enum " +
-          "\(String(describing: type(of: value))) = " +
-          "\(String(describing: value))"
-      )
-      value = defaultValue
-    }
-  }
+  var anyDiagnosticsEnabled: Bool { config.anyDiagnosticsEnabled }
 
   func validateConfig() throws {
-    if URL(string: metricsLoggingURL) == nil {
-      throw ClientConfigError.invalidURL(urlString: metricsLoggingURL)
-    }
-    if metricsLoggingAPIKey.isEmpty {
-      throw ClientConfigError.missingAPIKey
-    }
-    if !devMetricsLoggingURL.isEmpty {
-      if URL(string: devMetricsLoggingURL) == nil {
-        throw ClientConfigError.invalidURL(urlString: devMetricsLoggingURL)
-      }
-      if devMetricsLoggingAPIKey.isEmpty {
-        throw ClientConfigError.missingDevAPIKey
-      }
-    }
+    try config.validateConfig()
   }
 }
 
 // MARK: - Testing
 extension ClientConfig {
   mutating func disableAssertInValidationForTesting() {
-    assertInValidation = false
+    config.disableAssertInValidationForTesting()
   }
 }
 
@@ -455,72 +156,4 @@ protocol InitialConfigSource {
 
 protocol ClientConfigSource: InitialConfigSource {
   var clientConfig: ClientConfig { get }
-}
-
-// MARK: - Comparison and serialization
-public func < <T: RawRepresentable>(
-  a: T, b: T
-) -> Bool where T.RawValue: Comparable {
-  return a.rawValue < b.rawValue
-}
-
-public extension _ConfigEnum {
-  init?(_ name: String) {
-    for value in Self.allCases {
-      if value.description == name {
-        self = value
-        return
-      }
-    }
-    return nil
-  }
-}
-
-extension ClientConfig.MetricsLoggingWireFormat {
-  public var description: String {
-    switch self {
-    case .json:
-      return "json"
-    case .binary:
-      return "binary"
-    default:
-      return "unknown"
-    }
-  }
-}
-
-extension ClientConfig.XrayLevel {
-  public var description: String {
-    switch self {
-    case .none:
-      return "none"
-    case .batchSummaries:
-      return "batchSummaries"
-    case .callDetails:
-      return "callDetails"
-    case .callDetailsAndStackTraces:
-      return "callDetailsAndStackTraces"
-    default:
-      return "unknown"
-    }
-  }
-}
-
-extension ClientConfig.OSLogLevel {
-  public var description: String {
-    switch self {
-    case .none:
-      return "none"
-    case .error:
-      return "error"
-    case .warning:
-      return "warning"
-    case .info:
-      return "info"
-    case .debug:
-      return "debug"
-    default:
-      return "unknown"
-    }
-  }
 }

--- a/Sources/PromotedCore/ClientConfig/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/ClientConfig.swift
@@ -1,14 +1,7 @@
 import Foundation
 
 public protocol _ConfigEnum:
-  CaseIterable,
-  Codable,
-  CustomStringConvertible,
-  Equatable,
-  ExpressibleByStringLiteral
-{
-  static var unknownValue: Self { get }
-}
+  CaseIterable, Codable, CustomStringConvertible, Equatable {}
 
 // MARK: - ClientConfig properties
 /**
@@ -32,7 +25,6 @@ public protocol _ConfigEnum:
  2. Make the type `@objc` and give it a name prefixed with `PRO`.
  3. Make it an `Int` enum.
  4. Make it conform to `ConfigEnum`.
- 5. Give it a `case unknown = 0`.
 
  The final three items ensure that it works with remote config
  and serialization.
@@ -41,7 +33,6 @@ public protocol _ConfigEnum:
  ```swift
  @objc(PROAlohaEnum)
  public enum AlohaEnum: Int, ConfigEnum {
-   case unknown = 0
    case hello = 1
    case goodbye = 2
  }
@@ -105,7 +96,6 @@ public struct ClientConfig: Codable {
   /// Format to use when sending protobuf log messages over network.
   @objc(PROMetricsLoggingWireFormat)
   public enum MetricsLoggingWireFormat: Int, ConfigEnum {
-    case unknown = 0
     /// https://developers.google.com/protocol-buffers/docs/proto3#json
     case json = 1
     /// https://developers.google.com/protocol-buffers/docs/encoding
@@ -147,7 +137,6 @@ public struct ClientConfig: Codable {
 
   @objc(PROXrayLevel)
   public enum XrayLevel: Int, Comparable, ConfigEnum {
-    case unknown = 0
     // Don't gather any Xray stats data at all.
     case none = 1
     // Gather overall counts for the session for each batch.
@@ -175,7 +164,6 @@ public struct ClientConfig: Codable {
 
   @objc(PROOSLogLevel)
   public enum OSLogLevel: Int, Comparable, ConfigEnum {
-    case unknown = 0
     /// No logging for anything.
     case none = 1
     /// Logging only for errors.
@@ -379,7 +367,7 @@ extension ClientConfig {
     defaultValue: T,
     propertyName: String = #function
   ) {
-    if !T.allCases.contains(value) || value == T.unknownValue {
+    if !T.allCases.contains(value) {
       assert(
         !assertInValidation,
         "\(propertyName): unknown case for enum " +
@@ -432,20 +420,18 @@ public func < <T: RawRepresentable>(
 }
 
 public extension _ConfigEnum {
-  init(stringLiteral: String) {
+  init?(name: String) {
     for value in Self.allCases {
-      if value.description == stringLiteral {
+      if value.description == name {
         self = value
         return
       }
     }
-    self = Self.unknownValue
+    return nil
   }
 }
 
 extension ClientConfig.MetricsLoggingWireFormat {
-  public static var unknownValue: Self { .unknown }
-
   public var description: String {
     switch self {
     case .json:
@@ -459,8 +445,6 @@ extension ClientConfig.MetricsLoggingWireFormat {
 }
 
 extension ClientConfig.XrayLevel {
-  public static var unknownValue: Self { .unknown }
-
   public var description: String {
     switch self {
     case .none:
@@ -478,8 +462,6 @@ extension ClientConfig.XrayLevel {
 }
 
 extension ClientConfig.OSLogLevel {
-  public static var unknownValue: Self { .unknown }
-
   public var description: String {
     switch self {
     case .none:

--- a/Sources/PromotedCore/ClientConfig/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/ClientConfig.swift
@@ -74,7 +74,7 @@ public struct ClientConfig {
   }
 
   public init(_ config: _ObjCClientConfig) {
-    self.config = config
+    self.config = _ObjCClientConfig(config)
   }
 }
 

--- a/Sources/PromotedCore/ClientConfig/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/ClientConfig.swift
@@ -267,7 +267,8 @@ public extension ClientConfig {
     "devMetricsLoggingURL": \ClientConfig.devMetricsLoggingURL,
     "diagnosticsIncludeAncestorIDHistory":
       \ClientConfig.diagnosticsIncludeAncestorIDHistory,
-    "diagnosticsIncludeBatchSummaries": \ClientConfig.diagnosticsIncludeBatchSummaries,
+    "diagnosticsIncludeBatchSummaries":
+      \ClientConfig.diagnosticsIncludeBatchSummaries,
     "flushLoggingOnResignActive": \ClientConfig.flushLoggingOnResignActive,
     "loggingEnabled": \ClientConfig.loggingEnabled,
     "loggingFlushInterval": \ClientConfig.loggingFlushInterval,
@@ -275,9 +276,11 @@ public extension ClientConfig {
     "metricsLoggingWireFormat": \ClientConfig.metricsLoggingWireFormat,
     "metricsLoggingURL": \ClientConfig.metricsLoggingURL,
     "osLogLevel": \ClientConfig.osLogLevel,
-    "scrollTrackerDurationThreshold": \ClientConfig.scrollTrackerDurationThreshold,
+    "scrollTrackerDurationThreshold":
+      \ClientConfig.scrollTrackerDurationThreshold,
     "scrollTrackerUpdateFrequency": \ClientConfig.scrollTrackerUpdateFrequency,
-    "scrollTrackerVisibilityThreshold": \ClientConfig.scrollTrackerVisibilityThreshold,
+    "scrollTrackerVisibilityThreshold":
+      \ClientConfig.scrollTrackerVisibilityThreshold,
     "xrayLevel": \ClientConfig.xrayLevel,
   ]
 
@@ -285,7 +288,10 @@ public extension ClientConfig {
 
   /// Returns value for named property.
   func value(forName name: String) -> Any? {
-    guard let keyPath = Self.allKeyPaths[name] else { return nil }
+    guard let keyPath = Self.allKeyPaths[name] else {
+      assert(!assertInValidation, "Unknown key: \(name)")
+      return nil
+    }
     switch keyPath {
     case let k as ConfigKeyPath<Bool>:
       return self[keyPath: k]
@@ -312,7 +318,10 @@ public extension ClientConfig {
 
   /// Sets value for named property.
   mutating func setValue(_ value: Any, forName name: String) {
-    guard let keyPath = Self.allKeyPaths[name] else { return }
+    guard let keyPath = Self.allKeyPaths[name] else {
+      assert(!assertInValidation, "Unknown key: \(name)")
+      return
+    }
     switch value {
     case let intValue as Bool:
       if let k = keyPath as? WritableConfigKeyPath<Bool> {

--- a/Sources/PromotedCore/ClientConfig/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/ClientConfig.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Use `ClientConfig.ConfigEnum` instead.
 public protocol _ConfigEnum:
   CaseIterable, Codable, CustomStringConvertible, Equatable {}
 
@@ -9,22 +10,56 @@ public protocol _ConfigEnum:
  See `ClientConfigService` for information about how these
  configs are loaded.
 
- This class should only contain properties that apply to the
+ This struct should only contain properties that apply to the
  Promoted logging library in general. Mechanisms that alter
  the way that client code calls the Promoted logging library
  should go in client code, external from this config.
 
- Do not change the properties of this object once loaded from
- `ClientConfigService`.
+ # Objective C interoperability
 
- # Enums
+ The Objective C interoperability of this struct is contained
+ in a class called `_ObjCClientConfig`. Use that class only in
+ Objective C (where it's named `PROClientConfig`).
+
+ We chose to make this separate class for the following reasons.
+
+ 1. `ClientConfig` makes most sense as a struct in Swift, since
+    its semantics are always pass-by-value:
+    a. Attempting to maintain this as a class in Swift can lead
+       to hard-to-catch issues when forgetting to copy.
+    b. We need to make `ClientConfig` immutable after logging
+       services are started. Structs can be made read-only
+       easily because they are pass-by-value.
+ 2. Objective C can't work with Swift structs, only classes.
+ 3. The extra code needed to maintain this bridge can be tested,
+    but it's much harder to test for mis-uses of `ClientConfig`
+    as a class.
+
+ # Adding new properties.
+
+ When adding a new property, do the following:
+
+ 1. Ensure the type is `Codable` and can be expressed in
+    Objective C. If you're adding a new enum type as well,
+    see the next section.
+ 2. Add a property of same name and type in
+    `_ObjCClientConfig`.
+ 3. Add the property to the `allKeyPaths` map.
+ 4. If you added a new type that isn't covered by the switch
+    statements in `value(forName name: String)` and
+    `setValue(_ value: Any, forName name: String)`, add the
+    type in both switch statements.
+
+ # Adding new enums
 
  When adding a new enum property, do the following:
 
  1. Make the type and value public.
  2. Make the type `@objc` and give it a name prefixed with `PRO`.
+    The type will be referenced from `_ObjCClientConfig`.
  3. Make it an `Int` enum.
  4. Make it conform to `ConfigEnum`.
+ 5. Add an extension that contains `var description`.
 
  The final three items ensure that it works with remote config
  and serialization.
@@ -37,6 +72,18 @@ public protocol _ConfigEnum:
    case goodbye = 2
  }
  @objc public var aloha: AlohaEnum = .hello
+
+ extension ClientConfig.AlohaEnum {
+   public var description: String {
+     switch self {
+     case .hello:
+       return "hello"
+     case .goodbye:
+       return "goodbye"
+     default:
+       return "unknown"
+   }
+ }
  ```
 
  # Validation
@@ -47,6 +94,7 @@ public protocol _ConfigEnum:
  `bound` and `validateEnum`.
  */
 public struct ClientConfig: Codable {
+  /// Enumeration value in config.
   public typealias ConfigEnum = _ConfigEnum
 
   /// Controls whether log messages are sent over the network.

--- a/Sources/PromotedCore/ClientConfig/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/ClientConfig.swift
@@ -104,9 +104,7 @@ public struct ClientConfig {
   ) -> T {
     get { config[keyPath: keyPath] }
     set {
-      if !isKnownUniquelyReferenced(&config) {
-        config = _ObjCClientConfig(config)
-      }
+      ensureConfigUniquelyReferenced()
       config[keyPath: keyPath] = newValue
     }
   }
@@ -116,10 +114,14 @@ public struct ClientConfig {
   }
 
   public mutating func setValue(_ value: Any?, forKey key: String) {
+    ensureConfigUniquelyReferenced()
+    config.setValue(value, forKey: key)
+  }
+
+  private mutating func ensureConfigUniquelyReferenced() {
     if !isKnownUniquelyReferenced(&config) {
       config = _ObjCClientConfig(config)
     }
-    config.setValue(value, forKey: key)
   }
 
   public init() {}
@@ -131,6 +133,11 @@ public struct ClientConfig {
 
 // MARK: - Codable
 extension ClientConfig: Codable {}
+
+// MARK: - CustomReflectable
+extension ClientConfig: CustomReflectable {
+  public var customMirror: Mirror { Mirror(reflecting: config) }
+}
 
 // MARK: - Internal
 extension ClientConfig {

--- a/Sources/PromotedCore/ClientConfig/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/ClientConfig.swift
@@ -384,7 +384,7 @@ extension ClientConfig {
         !assertInValidation,
         "\(propertyName): unknown case for enum " +
           "\(String(describing: type(of: value))) = " +
-          "\(String(describing: value.rawValue))"
+          "\(String(describing: value))"
       )
       value = defaultValue
     }

--- a/Sources/PromotedCore/ClientConfig/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/ClientConfig.swift
@@ -6,88 +6,33 @@ import Foundation
  See `ClientConfigService` for information about how these
  configs are loaded.
 
- This struct should only contain properties that apply to the
+ `ClientConfig` should only contain properties that apply to the
  Promoted logging library in general. Mechanisms that alter
  the way that client code calls the Promoted logging library
  should go in client code, external from this config.
 
+ Properties should be added in `_ObjCClientConfig`. See that
+ class for instructions.
+
  # Objective C interoperability
 
- The Objective C interoperability of this struct is contained
- in a class called `_ObjCClientConfig`. Use that class only in
- Objective C (where it's named `PROClientConfig`).
+ This struct wraps a class called `_ObjCClientConfig`.
+ (Objective C can only use Swift classes, not structs.) The
+ underlying storage for all properties lies in that class. This
+ struct uses key paths to manage property access so that all
+ properties in the class are directly accessible via this
+ struct.
 
- We chose to make this separate class for the following reasons.
+ Furthermore, `ClientConfig` uses copy-on-write to preserve
+ pass-by-value semantics for structs. That is, if you make a
+ copy of this struct and modify the copy, the original remains
+ unchanged.
 
- 1. `ClientConfig` makes most sense as a struct in Swift, since
-    its semantics are always pass-by-value:
-    a. Attempting to maintain this as a class in Swift can lead
-       to hard-to-catch issues when forgetting to copy.
-    b. We need to make `ClientConfig` immutable after logging
-       services are started. Structs can be made read-only
-       easily because they are pass-by-value.
- 2. Objective C can't work with Swift structs, only classes.
- 3. The extra code needed to maintain this bridge can be tested,
-    but it's much harder to test for mis-uses of `ClientConfig`
-    as a class.
-
- # Adding new properties.
-
- When adding a new property, do the following:
-
- 1. Ensure the type is `Codable` and can be expressed in
-    Objective C. If you're adding a new enum type as well,
-    see the next section.
- 2. Add a property of same name and type in
-    `_ObjCClientConfig`.
- 3. Add the property to the `allKeyPaths` map.
- 4. If you added a new type that isn't covered by the switch
-    statements in `value(forName name: String)` and
-    `setValue(_ value: Any, forName name: String)`, add the
-    type in both switch statements.
-
- # Adding new enums
-
- When adding a new enum property, do the following:
-
- 1. Make the type and value public.
- 2. Make the type `@objc` and give it a name prefixed with `PRO`.
-    The type will be referenced from `_ObjCClientConfig`.
- 3. Make it an `Int` enum.
- 4. Make it conform to `ConfigEnum`.
- 5. Add an extension that contains `var description`.
-
- The final three items ensure that it works with remote config
- and serialization.
-
- Example:
- ```swift
- @objc(PROAlohaEnum)
- public enum AlohaEnum: Int, ConfigEnum {
-   case hello = 1
-   case goodbye = 2
- }
- @objc public var aloha: AlohaEnum = .hello
-
- extension ClientConfig.AlohaEnum {
-   public var description: String {
-     switch self {
-     case .hello:
-       return "hello"
-     case .goodbye:
-       return "goodbye"
-     default:
-       return "unknown"
-   }
- }
- ```
-
- # Validation
-
- When adding new properties that are numerical or enum values,
- make sure to validate in `didSet` to ensure that incorrect
- values don't cause unreasonable behavior during runtime. See
- `bound` and `validateEnum`.
+ The drawback of this approach is that, even though Swift code
+ should only interact with this struct, config properties all
+ need to go in `_ObjCClientConfig` instead of here. Still, this
+ approach gives us our desired behavior with minimal boilerplate
+ code, so it's still worth it.
  */
 @dynamicMemberLookup
 public struct ClientConfig {
@@ -97,7 +42,7 @@ public struct ClientConfig {
   public typealias XrayLevel = _ObjCClientConfig.XrayLevel
   public typealias OSLogLevel = _ObjCClientConfig.OSLogLevel
 
-  private var config: _ObjCClientConfig = _ObjCClientConfig()
+  private var config: _ObjCClientConfig
 
   public subscript<T>(
     dynamicMember keyPath: WritableKeyPath<_ObjCClientConfig, T>
@@ -124,7 +69,9 @@ public struct ClientConfig {
     }
   }
 
-  public init() {}
+  public init() {
+    self.config = _ObjCClientConfig()
+  }
 
   public init(_ config: _ObjCClientConfig) {
     self.config = config

--- a/Sources/PromotedCore/ClientConfig/ClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/ClientConfig.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+public protocol _ConfigEnum:
+  CaseIterable,
+  Codable,
+  CustomStringConvertible,
+  Equatable,
+  ExpressibleByStringLiteral
+{
+  static var unknownValue: Self { get }
+}
+
 // MARK: - ClientConfig properties
 /**
  Configuration for Promoted logging library internal behavior.
@@ -45,22 +55,20 @@ import Foundation
  values don't cause unreasonable behavior during runtime. See
  `bound` and `validateEnum`.
  */
-@objc(PROClientConfig)
-public final class ClientConfig: NSObject, Codable {
-  public typealias ConfigEnum =
-    CaseIterable & Codable & Equatable & ExpressibleByStringLiteral
+public struct ClientConfig: Codable {
+  public typealias ConfigEnum = _ConfigEnum
 
   /// Controls whether log messages are sent over the network.
   /// Setting this property to `false` will prevent log messages
   /// from being sent, but these messages may still be collected
   /// at runtime and stored in memory.
-  @objc public var loggingEnabled: Bool = true
+  public var loggingEnabled: Bool = true
 
   /// URL for logging endpoint as used by `NetworkConnection`.
   /// Implementations of `NetworkConnection` from Promoted will
   /// use this field. Custom implementations of `NetworkConnection`
   /// may vary in behavior.
-  @objc public var metricsLoggingURL: String = ""
+  public var metricsLoggingURL: String = ""
 
   /// URL for logging endpoint as used by `NetworkConnection`
   /// for debug/staging purposes. Used when the app is running
@@ -72,13 +80,13 @@ public final class ClientConfig: NSObject, Codable {
   /// Implementations of `NetworkConnection` from Promoted will
   /// use this field. Custom implementations of `NetworkConnection`
   /// may vary in behavior.
-  @objc public var devMetricsLoggingURL: String = ""
+  public var devMetricsLoggingURL: String = ""
   
   /// API key for logging endpoint.
   /// Implementations of `NetworkConnection` from Promoted will
   /// use this field. Custom implementations of `NetworkConnection`
   /// may vary in behavior.
-  @objc public var metricsLoggingAPIKey: String = ""
+  public var metricsLoggingAPIKey: String = ""
   
   /// API key for logging endpoint for debug/staging purposes.
   /// Used when the app is running in debug configuration.
@@ -89,10 +97,10 @@ public final class ClientConfig: NSObject, Codable {
   /// Implementations of `NetworkConnection` from Promoted will
   /// use this field. Custom implementations of `NetworkConnection`
   /// may vary in behavior.
-  @objc public var devMetricsLoggingAPIKey: String = ""
+  public var devMetricsLoggingAPIKey: String = ""
 
   /// HTTP header field for API key.
-  @objc public var apiKeyHTTPHeaderField: String = "x-api-key"
+  public var apiKeyHTTPHeaderField: String = "x-api-key"
 
   /// Format to use when sending protobuf log messages over network.
   @objc(PROMetricsLoggingWireFormat)
@@ -104,36 +112,36 @@ public final class ClientConfig: NSObject, Codable {
     case binary = 2
   }
   /// Format to use when sending protobuf log messages over network.
-  @objc public var metricsLoggingWireFormat: MetricsLoggingWireFormat = .binary {
+  public var metricsLoggingWireFormat: MetricsLoggingWireFormat = .binary {
     didSet { validateEnum(&metricsLoggingWireFormat, defaultValue: .binary) }
   }
 
   /// Interval at which log messages are sent over the network.
   /// Setting this to lower values will increase the frequency
   /// at which log messages are sent.
-  @objc public var loggingFlushInterval: TimeInterval = 10.0 {
+  public var loggingFlushInterval: TimeInterval = 10.0 {
     didSet { bound(&loggingFlushInterval, min: 1.0, max: 300.0) }
   }
 
   /// Whether to automatically flush all pending log messages
   /// when the application resigns active.
-  @objc public var flushLoggingOnResignActive: Bool = true
+  public var flushLoggingOnResignActive: Bool = true
 
   /// Ratio of the view that must be visible to log impression
   /// with `ScrollTracker`.
-  @objc public var scrollTrackerVisibilityThreshold: Float = 0.5 {
+  public var scrollTrackerVisibilityThreshold: Float = 0.5 {
     didSet { bound(&scrollTrackerVisibilityThreshold, min: 0.0, max: 1.0) }
   }
 
   /// Time on screen required to log impression with `ScrollTracker`.
-  @objc public var scrollTrackerDurationThreshold: TimeInterval = 1.0 {
+  public var scrollTrackerDurationThreshold: TimeInterval = 1.0 {
     didSet { bound(&scrollTrackerDurationThreshold, min: 0.0) }
   }
 
   /// Frequency at which `ScrollTracker` calculates impressions.
   /// Setting this to lower values will increase the amount of
   /// processing that `ScrollTracker` performs.
-  @objc public var scrollTrackerUpdateFrequency: TimeInterval = 0.5 {
+  public var scrollTrackerUpdateFrequency: TimeInterval = 0.5 {
     didSet { bound(&scrollTrackerUpdateFrequency, min: 0.1, max: 30.0) }
   }
 
@@ -156,7 +164,7 @@ public final class ClientConfig: NSObject, Codable {
   /// Level of Xray profiling for this session.
   /// Setting this to `.none` also forces
   /// `diagnosticsIncludeBatchSummaries` to be false.
-  @objc public var xrayLevel: XrayLevel = .none {
+  public var xrayLevel: XrayLevel = .none {
     didSet {
       validateEnum(&xrayLevel, defaultValue: .none)
       if xrayLevel == .none && diagnosticsIncludeBatchSummaries {
@@ -184,14 +192,14 @@ public final class ClientConfig: NSObject, Codable {
   /// verifying that logging works from the client side.
   /// If `xrayEnabled` is also set, then setting `osLogLevel`
   /// to `info` or higher turns on signposts in Instruments.
-  @objc public var osLogLevel: OSLogLevel = .none {
+  public var osLogLevel: OSLogLevel = .none {
     didSet { validateEnum(&osLogLevel, defaultValue: .none) }
   }
 
   /// Whether mobile diagnostic messages include batch summaries
   /// from Xray. Setting this to `true` also forces `xrayLevel` to
   /// be at least `.batchSummaries`.
-  @objc public var diagnosticsIncludeBatchSummaries: Bool = false {
+  public var diagnosticsIncludeBatchSummaries: Bool = false {
     didSet {
       if diagnosticsIncludeBatchSummaries && xrayLevel == .none {
         xrayLevel = .batchSummaries
@@ -201,7 +209,7 @@ public final class ClientConfig: NSObject, Codable {
 
   /// Whether mobile diagnostic messages include a history of
   /// ancestor IDs being set for the session.
-  @objc public var diagnosticsIncludeAncestorIDHistory: Bool = false
+  public var diagnosticsIncludeAncestorIDHistory: Bool = false
 
   var anyDiagnosticsEnabled: Bool {
     diagnosticsIncludeBatchSummaries ||
@@ -209,31 +217,131 @@ public final class ClientConfig: NSObject, Codable {
   }
 
   private var assertInValidation: Bool = true
+}
 
-  @objc public override init() {}
+// MARK: - Key paths
 
-  public init(_ config: ClientConfig) {
-    // ClientConfig really should be a struct, but isn't because
-    // of Objective C compatibility.
-    self.loggingEnabled = config.loggingEnabled
-    self.metricsLoggingURL = config.metricsLoggingURL
-    self.metricsLoggingAPIKey = config.metricsLoggingAPIKey
-    self.devMetricsLoggingURL = config.devMetricsLoggingURL
-    self.devMetricsLoggingAPIKey = config.devMetricsLoggingAPIKey
-    self.metricsLoggingWireFormat = config.metricsLoggingWireFormat
-    self.loggingFlushInterval = config.loggingFlushInterval
-    self.scrollTrackerVisibilityThreshold =
-      config.scrollTrackerVisibilityThreshold
-    self.scrollTrackerDurationThreshold =
-      config.scrollTrackerDurationThreshold
-    self.scrollTrackerUpdateFrequency =
-      config.scrollTrackerUpdateFrequency
-    self.xrayLevel = config.xrayLevel
-    self.osLogLevel = config.osLogLevel
-    self.diagnosticsIncludeBatchSummaries =
-      config.diagnosticsIncludeBatchSummaries
-    self.diagnosticsIncludeAncestorIDHistory =
-      config.diagnosticsIncludeAncestorIDHistory
+public extension ClientConfig {
+
+  typealias ConfigKeyPath<Value> = WritableKeyPath<ClientConfig, Value>
+
+  static let boolKeyPaths: [String: ConfigKeyPath<Bool>] = [
+    "loggingEnabled": \.loggingEnabled,
+    "flushLoggingOnResignActive": \.flushLoggingOnResignActive,
+    "diagnosticsIncludeBatchSummaries": \.diagnosticsIncludeBatchSummaries,
+    "diagnosticsIncludeAncestorIDHistory":
+      \.diagnosticsIncludeAncestorIDHistory
+  ]
+
+  static let stringKeyPaths: [String: ConfigKeyPath<String>] = [
+    "metricsLoggingURL": \.metricsLoggingURL,
+    "devMetricsLoggingURL": \.devMetricsLoggingURL,
+    "metricsLoggingAPIKey": \.metricsLoggingAPIKey,
+    "devMetricsLoggingAPIKey": \.devMetricsLoggingAPIKey,
+    "apiKeyHTTPHeaderField": \.apiKeyHTTPHeaderField
+  ]
+
+  static let timeIntervalKeyPaths: [String: ConfigKeyPath<TimeInterval>] = [
+    "loggingFlushInterval": \.loggingFlushInterval,
+    "scrollTrackerDurationThreshold": \.scrollTrackerDurationThreshold,
+    "scrollTrackerUpdateFrequency": \.scrollTrackerUpdateFrequency
+  ]
+
+  static let floatKeyPaths: [String: ConfigKeyPath<Float>] = [
+    "scrollTrackerVisibilityThreshold": \.scrollTrackerVisibilityThreshold
+  ]
+
+  static let metricsLoggingWireFormatKeyPaths: [String: ConfigKeyPath<ClientConfig.MetricsLoggingWireFormat>] = [
+    "metricsLoggingWireFormat": \.metricsLoggingWireFormat
+  ]
+
+  static let xrayLevelKeyPaths: [String: ConfigKeyPath<ClientConfig.XrayLevel>] = [
+    "xrayLevel": \.xrayLevel
+  ]
+
+  static let osLogLevelKeyPaths: [String: ConfigKeyPath<ClientConfig.OSLogLevel>] = [
+    "osLogLevel": \.osLogLevel
+  ]
+
+  static let allKeyPaths: [String: Any] = {
+    var result: [String: Any] = [:]
+    boolKeyPaths.forEach { result[$0] = $1 }
+    stringKeyPaths.forEach { result[$0] = $1 }
+    timeIntervalKeyPaths.forEach { result[$0] = $1 }
+    floatKeyPaths.forEach { result[$0] = $1 }
+    metricsLoggingWireFormatKeyPaths.forEach { result[$0] = $1 }
+    xrayLevelKeyPaths.forEach { result[$0] = $1 }
+    osLogLevelKeyPaths.forEach { result[$0] = $1 }
+    return result
+  } ()
+
+  func value(forName name: String) -> Any? {
+    guard let keyPath = Self.allKeyPaths[name] else { return nil }
+    switch keyPath {
+    case let k as ConfigKeyPath<Bool>:
+      return self[keyPath: k]
+    case let k as ConfigKeyPath<String>:
+      return self[keyPath: k]
+    case let k as ConfigKeyPath<TimeInterval>:
+      return self[keyPath: k]
+    case let k as ConfigKeyPath<Float>:
+      return self[keyPath: k]
+    case let k as ConfigKeyPath<ClientConfig.MetricsLoggingWireFormat>:
+      return self[keyPath: k]
+    case let k as ConfigKeyPath<ClientConfig.XrayLevel>:
+      return self[keyPath: k]
+    case let k as ConfigKeyPath<ClientConfig.OSLogLevel>:
+      return self[keyPath: k]
+    default:
+      return nil
+    }
+  }
+
+  mutating func setValue(_ value: Any, forName name: String) {
+    switch value {
+    case let intValue as Bool:
+      if let k = Self.boolKeyPaths[name] {
+        self[keyPath: k] = intValue
+      }
+    case let stringValue as String:
+      if let k = Self.stringKeyPaths[name] {
+        self[keyPath: k] = stringValue
+      }
+    case let timeValue as TimeInterval:
+      if let k = Self.timeIntervalKeyPaths[name] {
+        self[keyPath: k] = timeValue
+      }
+    case let floatValue as Float:
+      if let k = Self.floatKeyPaths[name] {
+        self[keyPath: k] = floatValue
+      }
+    case let m as ClientConfig.MetricsLoggingWireFormat:
+      if let k = Self.metricsLoggingWireFormatKeyPaths[name] {
+        self[keyPath: k] = m
+      }
+    case let x as ClientConfig.XrayLevel:
+      if let k = Self.xrayLevelKeyPaths[name] {
+        self[keyPath: k] = x
+      }
+    case let o as ClientConfig.OSLogLevel:
+      if let k = Self.osLogLevelKeyPaths[name] {
+        self[keyPath: k] = o
+      }
+    default:
+      break
+    }
+  }
+}
+
+// MARK: - ObjC compatibility
+public extension ClientConfig {
+
+  init(_ config: _ObjCClientConfig) {
+    let mirror = Mirror(reflecting: config)
+    for child in mirror.children {
+      guard let name = child.label else { continue }
+      setValue(child.value, forName: name)
+    }
   }
 }
 
@@ -296,7 +404,9 @@ extension ClientConfig {
 
 // MARK: - Testing
 extension ClientConfig {
-  func disableAssertInValidationForTesting() { assertInValidation = false }
+  mutating func disableAssertInValidationForTesting() {
+    assertInValidation = false
+  }
 }
 
 // MARK: - Protocol composition
@@ -315,54 +425,69 @@ public func < <T: RawRepresentable>(
   return a.rawValue < b.rawValue
 }
 
-public extension ClientConfig.MetricsLoggingWireFormat {
+public extension _ConfigEnum {
   init(stringLiteral: String) {
-    switch stringLiteral {
-    case "json":
-      self = .json
-    case "binary":
-      self = .binary
+    for value in Self.allCases {
+      if value.description == stringLiteral {
+        self = value
+        return
+      }
+    }
+    self = Self.unknownValue
+  }
+}
+
+extension ClientConfig.MetricsLoggingWireFormat {
+  public static var unknownValue: Self { .unknown }
+
+  public var description: String {
+    switch self {
+    case .json:
+      return "json"
+    case .binary:
+      return "binary"
     default:
-      self = .unknown
+      return "unknown"
     }
   }
 }
 
-public extension ClientConfig.XrayLevel {
-  init(stringLiteral: String) {
-    switch stringLiteral {
-    case "none":
-      self = .none
-    case "batchSummaries",
-         "batch_summaries":
-      self = .batchSummaries
-    case "callDetails",
-         "call_details":
-      self = .callDetails
-    case "callDetailsAndStackTraces",
-         "call_details_and_stack_traces":
-      self = .callDetailsAndStackTraces
+extension ClientConfig.XrayLevel {
+  public static var unknownValue: Self { .unknown }
+
+  public var description: String {
+    switch self {
+    case .none:
+      return "none"
+    case .batchSummaries:
+      return "batchSummaries"
+    case .callDetails:
+      return "callDetails"
+    case .callDetailsAndStackTraces:
+      return "callDetailsAndStackTraces"
     default:
-      self = .unknown
+      return "unknown"
     }
   }
 }
 
-public extension ClientConfig.OSLogLevel {
-  init(stringLiteral: String) {
-    switch stringLiteral {
-    case "none":
-      self = .none
-    case "error":
-      self = .error
-    case "warning":
-      self = .warning
-    case "info":
-      self = .info
-    case "debug":
-      self = .debug
+extension ClientConfig.OSLogLevel {
+  public static var unknownValue: Self { .unknown }
+
+  public var description: String {
+    switch self {
+    case .none:
+      return "none"
+    case .error:
+      return "error"
+    case .warning:
+      return "warning"
+    case .info:
+      return "info"
+    case .debug:
+      return "debug"
     default:
-      self = .unknown
+      return "unknown"
     }
   }
 }

--- a/Sources/PromotedCore/ClientConfig/ClientConfigService.swift
+++ b/Sources/PromotedCore/ClientConfig/ClientConfigService.swift
@@ -63,9 +63,9 @@ final class ClientConfigService {
   )
 
   init(deps: Deps) {
-    self._config = ClientConfig(deps.initialConfig)
+    self._config = deps.initialConfig
     self.wasConfigFetched = false
-    self.initialConfig = ClientConfig(deps.initialConfig)
+    self.initialConfig = deps.initialConfig
     self.store = deps.persistentStore
     self.remoteConfigConnection = deps.remoteConfigConnection
   }

--- a/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
@@ -32,9 +32,13 @@ public protocol ConfigEnum:
  3. Add a `typealias` to your type in `ClientConfig`. Swift
     code should only refer to the type in `ClientConfig`.
  4. Make it an `Int` enum.
- 5. Make it conform to `ConfigEnum`.
- 6. Add an extension that contains `var description`.
- 7. Add the enum to `value()` and `setValue()` workarounds.
+ 5. Give it a case with value 0, and make that case the default
+    value, or at least a harmless value. This is because any
+    invalid values for the enum will be evaluated to the raw
+    value of 0.
+ 6. Make it conform to `ConfigEnum`.
+ 7. Add an extension that contains `var description`.
+ 8. Add the enum to `value()` and `setValue()` workarounds.
 
  The final three items ensure that it works with remote config
  and serialization.
@@ -43,8 +47,8 @@ public protocol ConfigEnum:
  ```swift
  @objc(PROAlohaEnum)
  public enum AlohaEnum: Int, ConfigEnum {
-   case hello = 1
-   case goodbye = 2
+   case hello = 0
+   case goodbye = 1
  }
  @objc public var aloha: AlohaEnum = .hello
 
@@ -118,10 +122,10 @@ public final class _ObjCClientConfig: NSObject {
   /// Format to use when sending protobuf log messages over network.
   @objc(PROMetricsLoggingWireFormat)
   public enum MetricsLoggingWireFormat: Int, ConfigEnum {
+    /// https://developers.google.com/protocol-buffers/docs/encoding
+    case binary = 0
     /// https://developers.google.com/protocol-buffers/docs/proto3#json
     case json = 1
-    /// https://developers.google.com/protocol-buffers/docs/encoding
-    case binary = 2
   }
   /// Format to use when sending protobuf log messages over network.
   @objc public var metricsLoggingWireFormat:
@@ -162,17 +166,17 @@ public final class _ObjCClientConfig: NSObject {
   @objc(PROXrayLevel)
   public enum XrayLevel: Int, Comparable, ConfigEnum {
     // Don't gather any Xray stats data at all.
-    case none = 1
+    case none = 0
     // Gather overall counts for the session for each batch.
     // ie. batches: 40, batches sent successfully: 39, errors: 1
-    case batchSummaries = 2
+    case batchSummaries = 1
     // Gather stats and logged messages for each call made
     // to the metrics library.
-    case callDetails = 3
+    case callDetails = 2
     // Gathers stats and logged messages for each call made
     // to the metrics library, as well as stack traces where the
     // calls were made.
-    case callDetailsAndStackTraces = 4
+    case callDetailsAndStackTraces = 3
   }
   /// Level of Xray profiling for this session.
   /// Setting this to `.none` also forces
@@ -189,15 +193,15 @@ public final class _ObjCClientConfig: NSObject {
   @objc(PROOSLogLevel)
   public enum OSLogLevel: Int, Comparable, ConfigEnum {
     /// No logging for anything.
-    case none = 1
+    case none = 0
     /// Logging only for errors.
-    case error = 2
+    case error = 1
     /// Logging for errors and warnings.
-    case warning = 3
+    case warning = 2
     /// Logging for info messages (and above).
-    case info = 4
+    case info = 3
     /// Logging for debug messages (and above).
-    case debug = 5
+    case debug = 4
   }
   /// Whether to use OSLog (console logging) to output messages.
   /// OSLog typically incurs minimal overhead and can be useful for

--- a/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
@@ -35,6 +35,7 @@ public typealias ConfigEnum = (
  4. Make it an `Int` enum.
  5. Make it conform to `ConfigEnum`.
  6. Add an extension that contains `var description`.
+ 7. Add the enum to `value()` and `setValue()` workarounds.
 
  The final three items ensure that it works with remote config
  and serialization.
@@ -241,6 +242,8 @@ public final class _ObjCClientConfig: NSObject {
     }
   }
 
+  // There are some rough edges with Obj C interop and
+  // Swift enums. These next two methods deal with that.
   public override func value(forKey key: String) -> Any? {
     let value = super.value(forKey: key)
     switch key {

--- a/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
@@ -2,7 +2,11 @@ import Foundation
 
 /// Enumeration value in config.
 public protocol ConfigEnum:
-  CaseIterable, Codable, CustomStringConvertible, Equatable {}
+  CaseIterable,
+  Codable,
+  CustomStringConvertible,
+  Equatable,
+  RawRepresentable {}
 
 /**
  See `ClientConfig`. This class exists only for compatibility
@@ -164,7 +168,7 @@ public final class _ObjCClientConfig: NSObject {
       diagnosticsIncludeAncestorIDHistory
   }
 
-  private var assertInValidation: Bool = true
+  @objc private var assertInValidation: Bool = true
 
   /// Whether mobile diagnostic messages include a history of
   /// ancestor IDs being set for the session.
@@ -179,6 +183,42 @@ public final class _ObjCClientConfig: NSObject {
       guard let label = child.label else { continue }
       setValue(child.value, forKey: label)
     }
+  }
+
+  public override func value(forKey key: String) -> Any? {
+    let value = super.value(forKey: key)
+    switch key {
+    case "metricsLoggingWireFormat":
+      if let intValue = value as? Int {
+        return MetricsLoggingWireFormat(rawValue: intValue)
+      }
+    case "xrayLevel":
+      if let intValue = value as? Int {
+        return XrayLevel(rawValue: intValue)
+      }
+    case "osLogLevel":
+      if let intValue = value as? Int {
+        return OSLogLevel(rawValue: intValue)
+      }
+    default:
+      break
+    }
+    return value
+  }
+
+  public override func setValue(_ value: Any?, forKey key: String) {
+    let convertedValue: Any?
+    switch value {
+    case let wire as MetricsLoggingWireFormat:
+      convertedValue = wire.rawValue
+    case let xray as XrayLevel:
+      convertedValue = xray.rawValue
+    case let osLog as OSLogLevel:
+      convertedValue = osLog.rawValue
+    default:
+      convertedValue = value
+    }
+    super.setValue(convertedValue, forKey: key)
   }
 }
 

--- a/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+/// Enumeration value in config.
+public protocol ConfigEnum:
+  CaseIterable, Codable, CustomStringConvertible, Equatable {}
+
 /**
  See `ClientConfig`. This class exists only for compatibility
  with Objective C. Do not use from Swift.
@@ -7,38 +11,313 @@ import Foundation
 @objc(PROClientConfig)
 public final class _ObjCClientConfig: NSObject {
 
+  /// Controls whether log messages are sent over the network.
+  /// Setting this property to `false` will prevent log messages
+  /// from being sent, but these messages may still be collected
+  /// at runtime and stored in memory.
   @objc public var loggingEnabled: Bool = true
 
+  /// URL for logging endpoint as used by `NetworkConnection`.
+  /// Implementations of `NetworkConnection` from Promoted will
+  /// use this field. Custom implementations of `NetworkConnection`
+  /// may vary in behavior.
   @objc public var metricsLoggingURL: String = ""
 
+  /// URL for logging endpoint as used by `NetworkConnection`
+  /// for debug/staging purposes. Used when the app is running
+  /// in debug configuration.
+  ///
+  /// If this property is not set, then debug builds will use
+  /// `metricsLoggingURL` for logging endpoint URL.
+  ///
+  /// Implementations of `NetworkConnection` from Promoted will
+  /// use this field. Custom implementations of `NetworkConnection`
+  /// may vary in behavior.
   @objc public var devMetricsLoggingURL: String = ""
 
+  /// API key for logging endpoint.
+  /// Implementations of `NetworkConnection` from Promoted will
+  /// use this field. Custom implementations of `NetworkConnection`
+  /// may vary in behavior.
   @objc public var metricsLoggingAPIKey: String = ""
 
+  /// API key for logging endpoint for debug/staging purposes.
+  /// Used when the app is running in debug configuration.
+  ///
+  /// If this property is not set, then debug builds will use
+  /// `metricsLoggingAPIKey` for logging endpoint API key.
+  ///
+  /// Implementations of `NetworkConnection` from Promoted will
+  /// use this field. Custom implementations of `NetworkConnection`
+  /// may vary in behavior.
   @objc public var devMetricsLoggingAPIKey: String = ""
 
+  /// HTTP header field for API key.
   @objc public var apiKeyHTTPHeaderField: String = "x-api-key"
 
+  /// Format to use when sending protobuf log messages over network.
+  @objc(PROMetricsLoggingWireFormat)
+  public enum MetricsLoggingWireFormat: Int, ConfigEnum {
+    /// https://developers.google.com/protocol-buffers/docs/proto3#json
+    case json = 1
+    /// https://developers.google.com/protocol-buffers/docs/encoding
+    case binary = 2
+  }
+  /// Format to use when sending protobuf log messages over network.
   @objc public var metricsLoggingWireFormat:
-    ClientConfig.MetricsLoggingWireFormat = .binary
+    MetricsLoggingWireFormat = .binary
+  {
+    didSet { validateEnum(&metricsLoggingWireFormat, defaultValue: .binary) }
+  }
 
-  @objc public var loggingFlushInterval: TimeInterval = 10.0
+  /// Interval at which log messages are sent over the network.
+  /// Setting this to lower values will increase the frequency
+  /// at which log messages are sent.
+  @objc public var loggingFlushInterval: TimeInterval = 10.0 {
+    didSet { bound(&loggingFlushInterval, min: 1.0, max: 300.0) }
+  }
 
+  /// Whether to automatically flush all pending log messages
+  /// when the application resigns active.
   @objc public var flushLoggingOnResignActive: Bool = true
 
-  @objc public var scrollTrackerVisibilityThreshold: Float = 0.5
+  /// Ratio of the view that must be visible to log impression
+  /// with `ScrollTracker`.
+  @objc public var scrollTrackerVisibilityThreshold: Float = 0.5 {
+    didSet { bound(&scrollTrackerVisibilityThreshold, min: 0.0, max: 1.0) }
+  }
 
-  @objc public var scrollTrackerDurationThreshold: TimeInterval = 1.0
+  /// Time on screen required to log impression with `ScrollTracker`.
+  @objc public var scrollTrackerDurationThreshold: TimeInterval = 1.0 {
+    didSet { bound(&scrollTrackerDurationThreshold, min: 0.0) }
+  }
 
-  @objc public var scrollTrackerUpdateFrequency: TimeInterval = 0.5
+  /// Frequency at which `ScrollTracker` calculates impressions.
+  /// Setting this to lower values will increase the amount of
+  /// processing that `ScrollTracker` performs.
+  @objc public var scrollTrackerUpdateFrequency: TimeInterval = 0.5 {
+    didSet { bound(&scrollTrackerUpdateFrequency, min: 0.1, max: 30.0) }
+  }
 
-  @objc public var xrayLevel: ClientConfig.XrayLevel = .none
+  @objc(PROXrayLevel)
+  public enum XrayLevel: Int, Comparable, ConfigEnum {
+    // Don't gather any Xray stats data at all.
+    case none = 1
+    // Gather overall counts for the session for each batch.
+    // ie. batches: 40, batches sent successfully: 39, errors: 1
+    case batchSummaries = 2
+    // Gather stats and logged messages for each call made
+    // to the metrics library.
+    case callDetails = 3
+    // Gathers stats and logged messages for each call made
+    // to the metrics library, as well as stack traces where the
+    // calls were made.
+    case callDetailsAndStackTraces = 4
+  }
+  /// Level of Xray profiling for this session.
+  /// Setting this to `.none` also forces
+  /// `diagnosticsIncludeBatchSummaries` to be false.
+  @objc public var xrayLevel: XrayLevel = .none {
+    didSet {
+      validateEnum(&xrayLevel, defaultValue: .none)
+      if xrayLevel == .none && diagnosticsIncludeBatchSummaries {
+        diagnosticsIncludeBatchSummaries = false
+      }
+    }
+  }
 
-  @objc public var osLogLevel: ClientConfig.OSLogLevel = .none
+  @objc(PROOSLogLevel)
+  public enum OSLogLevel: Int, Comparable, ConfigEnum {
+    /// No logging for anything.
+    case none = 1
+    /// Logging only for errors.
+    case error = 2
+    /// Logging for errors and warnings.
+    case warning = 3
+    /// Logging for info messages (and above).
+    case info = 4
+    /// Logging for debug messages (and above).
+    case debug = 5
+  }
+  /// Whether to use OSLog (console logging) to output messages.
+  /// OSLog typically incurs minimal overhead and can be useful for
+  /// verifying that logging works from the client side.
+  /// If `xrayEnabled` is also set, then setting `osLogLevel`
+  /// to `info` or higher turns on signposts in Instruments.
+  @objc public var osLogLevel: OSLogLevel = .none {
+    didSet { validateEnum(&osLogLevel, defaultValue: .none) }
+  }
 
-  @objc public var diagnosticsIncludeBatchSummaries: Bool = false
+  /// Whether mobile diagnostic messages include batch summaries
+  /// from Xray. Setting this to `true` also forces `xrayLevel` to
+  /// be at least `.batchSummaries`.
+  @objc public var diagnosticsIncludeBatchSummaries: Bool = false {
+    didSet {
+      if diagnosticsIncludeBatchSummaries && xrayLevel == .none {
+        xrayLevel = .batchSummaries
+      }
+    }
+  }
 
+  var anyDiagnosticsEnabled: Bool {
+    diagnosticsIncludeBatchSummaries ||
+      diagnosticsIncludeAncestorIDHistory
+  }
+
+  private var assertInValidation: Bool = true
+
+  /// Whether mobile diagnostic messages include a history of
+  /// ancestor IDs being set for the session.
   @objc public var diagnosticsIncludeAncestorIDHistory: Bool = false
 
   @objc public override init() {}
+
+  convenience init(_ other: _ObjCClientConfig) {
+    self.init()
+    let mirror = Mirror(reflecting: other)
+    for child in mirror.children {
+      guard let label = child.label else { continue }
+      setValue(child.value, forKey: label)
+    }
+  }
+}
+
+// MARK: - Codable
+extension _ObjCClientConfig: Codable {}
+
+// MARK: - Validation
+extension _ObjCClientConfig {
+
+  private func bound<T: Comparable>(
+    _ value: inout T,
+    min: T? = nil,
+    max: T? = nil,
+    propertyName: String = #function
+  ) {
+    if let min = min {
+      assert(
+        !assertInValidation || value >= min,
+        "\(propertyName): min value \(min) (> \(value))"
+      )
+      value = Swift.max(min, value)
+    }
+    if let max = max {
+      assert(
+        !assertInValidation || value <= max,
+        "\(propertyName): max value \(max) (< \(value))"
+      )
+      value = Swift.min(max, value)
+    }
+  }
+
+  /// Validate enums and set them to appropriate defaults.
+  /// Deserialization might produce invalid enum values.
+  private func validateEnum<T: ConfigEnum>(
+    _ value: inout T,
+    defaultValue: T,
+    propertyName: String = #function
+  ) {
+    if !T.allCases.contains(value) {
+      assert(
+        !assertInValidation,
+        "\(propertyName): unknown case for enum " +
+          "\(String(describing: type(of: value))) = " +
+          "\(String(describing: value))"
+      )
+      value = defaultValue
+    }
+  }
+
+  func validateConfig() throws {
+    if URL(string: metricsLoggingURL) == nil {
+      throw ClientConfigError.invalidURL(urlString: metricsLoggingURL)
+    }
+    if metricsLoggingAPIKey.isEmpty {
+      throw ClientConfigError.missingAPIKey
+    }
+    if !devMetricsLoggingURL.isEmpty {
+      if URL(string: devMetricsLoggingURL) == nil {
+        throw ClientConfigError.invalidURL(urlString: devMetricsLoggingURL)
+      }
+      if devMetricsLoggingAPIKey.isEmpty {
+        throw ClientConfigError.missingDevAPIKey
+      }
+    }
+  }
+}
+
+// MARK: - Testing
+extension _ObjCClientConfig {
+  func disableAssertInValidationForTesting() {
+    assertInValidation = false
+  }
+}
+
+// MARK: - ConfigEnums
+public extension ConfigEnum {
+  init?(_ name: String) {
+    for value in Self.allCases {
+      if value.description == name {
+        self = value
+        return
+      }
+    }
+    return nil
+  }
+}
+
+extension _ObjCClientConfig.MetricsLoggingWireFormat {
+  public var description: String {
+    switch self {
+    case .json:
+      return "json"
+    case .binary:
+      return "binary"
+    default:
+      return "unknown"
+    }
+  }
+}
+
+extension _ObjCClientConfig.XrayLevel {
+  public var description: String {
+    switch self {
+    case .none:
+      return "none"
+    case .batchSummaries:
+      return "batchSummaries"
+    case .callDetails:
+      return "callDetails"
+    case .callDetailsAndStackTraces:
+      return "callDetailsAndStackTraces"
+    default:
+      return "unknown"
+    }
+  }
+}
+
+extension _ObjCClientConfig.OSLogLevel {
+  public var description: String {
+    switch self {
+    case .none:
+      return "none"
+    case .error:
+      return "error"
+    case .warning:
+      return "warning"
+    case .info:
+      return "info"
+    case .debug:
+      return "debug"
+    default:
+      return "unknown"
+    }
+  }
+}
+
+// MARK: - Comparison and serialization
+public func < <T: RawRepresentable>(
+  a: T, b: T
+) -> Bool where T.RawValue: Comparable {
+  return a.rawValue < b.rawValue
 }

--- a/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
@@ -1,13 +1,12 @@
 import Foundation
 
 /// Enumeration value in config.
-public typealias ConfigEnum = (
-  CaseIterable &
-  Codable &
-  CustomStringConvertible &
-  Equatable &
-  RawRepresentable
-)
+public protocol ConfigEnum:
+  CaseIterable,
+  Codable,
+  CustomStringConvertible,
+  Equatable,
+  RawRepresentable {}
 
 /**
  See `ClientConfig`. This class exists only for compatibility

--- a/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+/**
+ See `ClientConfig`. This class exists only for compatibility
+ with Objective C. Do not use from Swift.
+ */
 @objc(PROClientConfig)
 public final class _ObjCClientConfig: NSObject {
 

--- a/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+@objc(PROClientConfig)
+public final class _ObjCClientConfig: NSObject {
+
+  @objc public var loggingEnabled: Bool = true
+
+  @objc public var metricsLoggingURL: String = ""
+
+  @objc public var devMetricsLoggingURL: String = ""
+
+  @objc public var metricsLoggingAPIKey: String = ""
+
+  @objc public var devMetricsLoggingAPIKey: String = ""
+
+  @objc public var apiKeyHTTPHeaderField: String = "x-api-key"
+
+  @objc public var metricsLoggingWireFormat:
+    ClientConfig.MetricsLoggingWireFormat = .binary
+
+  @objc public var loggingFlushInterval: TimeInterval = 10.0
+
+  @objc public var flushLoggingOnResignActive: Bool = true
+
+  @objc public var scrollTrackerVisibilityThreshold: Float = 0.5
+
+  @objc public var scrollTrackerDurationThreshold: TimeInterval = 1.0
+
+  @objc public var scrollTrackerUpdateFrequency: TimeInterval = 0.5
+
+  @objc public var xrayLevel: ClientConfig.XrayLevel = .none
+
+  @objc public var osLogLevel: ClientConfig.OSLogLevel = .none
+
+  @objc public var diagnosticsIncludeBatchSummaries: Bool = false
+
+  @objc public var diagnosticsIncludeAncestorIDHistory: Bool = false
+
+  @objc public override init() {}
+}

--- a/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
@@ -1,16 +1,72 @@
 import Foundation
 
 /// Enumeration value in config.
-public protocol ConfigEnum:
-  CaseIterable,
-  Codable,
-  CustomStringConvertible,
-  Equatable,
-  RawRepresentable {}
+public typealias ConfigEnum = (
+  CaseIterable &
+  Codable &
+  CustomStringConvertible &
+  Equatable &
+  RawRepresentable
+)
 
 /**
  See `ClientConfig`. This class exists only for compatibility
  with Objective C. Do not use from Swift.
+
+ Add new config properties in this class.
+
+ # Adding new properties.
+
+ When adding a new property, do the following:
+
+ 1. Add the property in this class.
+ 2. Ensure the type is `Codable` and can be expressed in
+    Objective C.
+ 3. Make the property `@objc`.
+
+ # Adding new enums
+
+ When adding a new enum property, do the following:
+
+ 1. Add the type in this class.
+ 2. Make the type `@objc` and prefix its name with `PRO`.
+ 3. Add a `typealias` to your type in `ClientConfig`. Swift
+    code should only refer to the type in `ClientConfig`.
+ 4. Make it an `Int` enum.
+ 5. Make it conform to `ConfigEnum`.
+ 6. Add an extension that contains `var description`.
+
+ The final three items ensure that it works with remote config
+ and serialization.
+
+ Example:
+ ```swift
+ @objc(PROAlohaEnum)
+ public enum AlohaEnum: Int, ConfigEnum {
+   case hello = 1
+   case goodbye = 2
+ }
+ @objc public var aloha: AlohaEnum = .hello
+
+ extension ClientConfig.AlohaEnum {
+   public var description: String {
+     switch self {
+     case .hello:
+       return "hello"
+     case .goodbye:
+       return "goodbye"
+     default:
+       return "unknown"
+   }
+ }
+ ```
+
+ # Validation
+
+ When adding new properties that are numerical or enum values,
+ make sure to validate in `didSet` to ensure that incorrect
+ values don't cause unreasonable behavior during runtime. See
+ `bound` and `validateEnum`.
  */
 @objc(PROClientConfig)
 public final class _ObjCClientConfig: NSObject {

--- a/Sources/PromotedCore/MetricsLogger.swift
+++ b/Sources/PromotedCore/MetricsLogger.swift
@@ -49,7 +49,7 @@ import os.log
 public final class MetricsLogger: NSObject {
 
   private unowned let clock: Clock
-  private unowned let config: ClientConfig
+  private let config: ClientConfig
   private unowned let connection: NetworkConnection
   private unowned let deviceInfo: DeviceInfo
   private unowned let idMap: IDMap

--- a/Sources/PromotedCore/MetricsLoggerService.swift
+++ b/Sources/PromotedCore/MetricsLoggerService.swift
@@ -113,8 +113,10 @@ public final class MetricsLoggerService: NSObject {
   }
   public private(set) var startupResult: StartupResult
 
-  @objc public convenience init(coreInitialConfig: _ObjCClientConfig) throws {
-    try self.init(coreInitialConfig: ClientConfig(coreInitialConfig))
+  @objc public convenience init(
+    objcCoreInitialConfig: _ObjCClientConfig
+  ) throws {
+    try self.init(coreInitialConfig: ClientConfig(objcCoreInitialConfig))
   }
 
   /// Creates a new service with a core configuration.

--- a/Sources/PromotedCore/MetricsLoggerService.swift
+++ b/Sources/PromotedCore/MetricsLoggerService.swift
@@ -245,8 +245,11 @@ public extension MetricsLoggerService {
 
   private static var moduleConfig: ModuleConfig?
 
-  @objc static func startServices(coreInitialConfig: _ObjCClientConfig) throws {
-    try startServices(coreInitialConfig: ClientConfig(coreInitialConfig))
+  @objc(startServicesWithCoreInitialConfig:error:)
+  static func startServices(
+    objCCoreInitialConfig: _ObjCClientConfig
+  ) throws {
+    try startServices(coreInitialConfig: ClientConfig(objCCoreInitialConfig))
   }
 
   /// Call this to start logging services, prior to accessing `sharedService`.

--- a/Sources/PromotedCore/MetricsLoggerService.swift
+++ b/Sources/PromotedCore/MetricsLoggerService.swift
@@ -100,7 +100,7 @@ public final class MetricsLoggerService: NSObject {
     return MetricsLogger(deps: module)
   } ()
 
-  @objc public var config: ClientConfig { module.clientConfig }
+  public var config: ClientConfig { module.clientConfig }
 
   @objc public var xray: Xray? { module.xray }
 
@@ -113,13 +113,17 @@ public final class MetricsLoggerService: NSObject {
   }
   public private(set) var startupResult: StartupResult
 
+  @objc public convenience init(coreInitialConfig: _ObjCClientConfig) throws {
+    try self.init(coreInitialConfig: ClientConfig(coreInitialConfig))
+  }
+
   /// Creates a new service with a core configuration.
   /// This does not provide a `NetworkConnection`. If you are not
   /// supplying your own `NetworkConnection`, you should use
   /// `init(initialConfig:)` from the `PromotedMetrics` dependency.
   ///
   /// Initialization errors may not be logged to analytics.
-  @objc public convenience init(coreInitialConfig: ClientConfig) throws {
+  public convenience init(coreInitialConfig: ClientConfig) throws {
     let moduleConfig = ModuleConfig.coreConfig()
     moduleConfig.initialConfig = coreInitialConfig
     try self.init(moduleConfig: moduleConfig)
@@ -173,17 +177,21 @@ private extension MetricsLoggerService {
 
   private func startObservingApplicationLifecycle() {
     let nc = NotificationCenter.default
-    nc.addObserver(self,
-                   selector: #selector(applicationWillResignActive),
-                   name: UIApplication.willResignActiveNotification,
-                   object: nil)
+    nc.addObserver(
+      self,
+      selector: #selector(applicationWillResignActive),
+      name: UIApplication.willResignActiveNotification,
+      object: nil
+    )
   }
 
   private func stopObservingApplicationLifecycle() {
     let nc = NotificationCenter.default
-    nc.removeObserver(self,
-                      name: UIApplication.willResignActiveNotification,
-                      object: nil)
+    nc.removeObserver(
+      self,
+      name: UIApplication.willResignActiveNotification,
+      object: nil
+    )
   }
 
   @objc private func applicationWillResignActive() {
@@ -214,17 +222,21 @@ public extension MetricsLoggerService {
   /// via `setFramesFrom(collectionView:...)` to initiate tracking.
   @objc func scrollTracker(scrollView: UIScrollView) -> ScrollTracker? {
     guard let metricsLogger = self.metricsLogger else { return nil }
-    return ScrollTracker(metricsLogger: metricsLogger,
-                         scrollView: scrollView,
-                         deps: module)
+    return ScrollTracker(
+      metricsLogger: metricsLogger,
+      scrollView: scrollView,
+      deps: module
+    )
   }
 
   /// Returns a new `ScrollTracker` tied to the given `UICollectionView`.
   @objc func scrollTracker(collectionView: UICollectionView) -> ScrollTracker? {
     guard let metricsLogger = self.metricsLogger else { return nil }
-    return ScrollTracker(metricsLogger: metricsLogger,
-                         collectionView: collectionView,
-                         deps: module)
+    return ScrollTracker(
+      metricsLogger: metricsLogger,
+      collectionView: collectionView,
+      deps: module
+    )
   }
 }
 
@@ -233,6 +245,10 @@ public extension MetricsLoggerService {
 
   private static var moduleConfig: ModuleConfig?
 
+  @objc static func startServices(coreInitialConfig: _ObjCClientConfig) throws {
+    try startServices(coreInitialConfig: ClientConfig(coreInitialConfig))
+  }
+
   /// Call this to start logging services, prior to accessing `sharedService`.
   /// This does not provide a `NetworkConnection`. If you are not
   /// supplying your own `NetworkConnection`, you should use
@@ -240,7 +256,7 @@ public extension MetricsLoggerService {
   ///
   /// Equivalent to calling `init`, then `startLoggingServices()` on
   /// the shared service.
-  @objc static func startServices(coreInitialConfig: ClientConfig) throws {
+  static func startServices(coreInitialConfig: ClientConfig) throws {
     let moduleConfig = ModuleConfig.coreConfig()
     moduleConfig.initialConfig = coreInitialConfig
     try startServices(moduleConfig: moduleConfig)
@@ -259,7 +275,10 @@ public extension MetricsLoggerService {
   /// was not called.
   @objc(sharedService)
   static let shared: MetricsLoggerService = {
-    assert(moduleConfig != nil, "Call startServices() before accessing shared service")
+    assert(
+      moduleConfig != nil,
+      "Call startServices() before accessing shared service"
+    )
     return try! MetricsLoggerService(moduleConfig: moduleConfig!)
   } ()
 }

--- a/Sources/PromotedCore/Module.swift
+++ b/Sources/PromotedCore/Module.swift
@@ -13,7 +13,9 @@ import os.log
  */
 @objc(PROModuleConfig)
 public final class ModuleConfig: NSObject {
-  @objc public var initialConfig = ClientConfig()
+  @objc(initialConfig)
+  public var _objCInitialConfig = _ObjCClientConfig()
+  public var initialConfig = ClientConfig()
   public var analyticsConnection: AnalyticsConnection? = nil
   public var networkConnection: NetworkConnection? = nil
   public var persistentStore: PersistentStore? = nil
@@ -212,7 +214,7 @@ final class Module: AllDeps {
     persistentStore: PersistentStore? = nil,
     remoteConfigConnection: RemoteConfigConnection? = nil
   ) {
-    self.initialConfig = ClientConfig(initialConfig)
+    self.initialConfig = initialConfig
     self.analyticsConnection = analyticsConnection
     self.networkConnectionSpec = networkConnection
     self.persistentStoreSpec = persistentStore

--- a/Sources/PromotedCore/Module.swift
+++ b/Sources/PromotedCore/Module.swift
@@ -13,13 +13,24 @@ import os.log
  */
 @objc(PROModuleConfig)
 public final class ModuleConfig: NSObject {
+
   @objc(initialConfig)
   public var _objCInitialConfig = _ObjCClientConfig()
+
   public var initialConfig = ClientConfig()
+
   public var analyticsConnection: AnalyticsConnection? = nil
+
   public var networkConnection: NetworkConnection? = nil
+
   public var persistentStore: PersistentStore? = nil
+
   public var remoteConfigConnection: RemoteConfigConnection? = nil
+
+  fileprivate var initialConfigForModule: ClientConfig {
+    !_objCInitialConfig.metricsLoggingURL.isEmpty ?
+      ClientConfig(_objCInitialConfig) : initialConfig
+  }
 
   private override init() {}
 
@@ -199,7 +210,7 @@ final class Module: AllDeps {
 
   convenience init(moduleConfig: ModuleConfig) {
     self.init(
-      initialConfig: moduleConfig.initialConfig,
+      initialConfig: moduleConfig.initialConfigForModule,
       analyticsConnection: moduleConfig.analyticsConnection,
       networkConnection: moduleConfig.networkConnection,
       persistentStore: moduleConfig.persistentStore,

--- a/Sources/PromotedCore/NetworkConnection.swift
+++ b/Sources/PromotedCore/NetworkConnection.swift
@@ -61,8 +61,6 @@ public extension NetworkConnection {
       return try message.serializedData()
     case .json:
       return try message.jsonUTF8Data()
-    case .unknown:
-      throw ClientConfigError.invalidWireFormat
     }
   }
 

--- a/Sources/PromotedFirebaseRemoteConfig/ClientConfig+PromotedFirebaseRemoteConfig.swift
+++ b/Sources/PromotedFirebaseRemoteConfig/ClientConfig+PromotedFirebaseRemoteConfig.swift
@@ -105,16 +105,11 @@ extension ClientConfig {
     case is String:
       return remoteValue
     case is ClientConfig.MetricsLoggingWireFormat:
-      let value = ClientConfig.MetricsLoggingWireFormat(
-        stringLiteral: remoteValue
-      )
-      return value == .unknown ? nil : value
+      return ClientConfig.MetricsLoggingWireFormat(name: remoteValue)
     case is ClientConfig.XrayLevel:
-      let value = ClientConfig.XrayLevel(stringLiteral: remoteValue)
-      return value == .unknown ? nil : value
+      return ClientConfig.XrayLevel(name: remoteValue)
     case is ClientConfig.OSLogLevel:
-      let value = ClientConfig.OSLogLevel(stringLiteral: remoteValue)
-      return value == .unknown ? nil : value
+      return ClientConfig.OSLogLevel(name: remoteValue)
     default:
       return nil
     }

--- a/Sources/PromotedFirebaseRemoteConfig/ClientConfig+PromotedFirebaseRemoteConfig.swift
+++ b/Sources/PromotedFirebaseRemoteConfig/ClientConfig+PromotedFirebaseRemoteConfig.swift
@@ -92,32 +92,28 @@ extension ClientConfig {
   }
 
   private func convertedValue(
-    forRemoteValue value: String,
+    forRemoteValue remoteValue: String,
     child: Mirror.Child
   ) -> Any? {
     switch child.value {
     case is Int:
-      return Int(value)
+      return Int(remoteValue)
     case is Double:
-      return Double(value)
+      return Double(remoteValue)
     case is Bool:
-      return Bool(value)
+      return Bool(remoteValue)
     case is String:
-      return value
+      return remoteValue
     case is ClientConfig.MetricsLoggingWireFormat:
       let value = ClientConfig.MetricsLoggingWireFormat(
-        stringLiteral: value
+        stringLiteral: remoteValue
       )
       return value == .unknown ? nil : value
     case is ClientConfig.XrayLevel:
-      let value = ClientConfig.XrayLevel(
-        stringLiteral: value
-      )
+      let value = ClientConfig.XrayLevel(stringLiteral: remoteValue)
       return value == .unknown ? nil : value
     case is ClientConfig.OSLogLevel:
-      let value = ClientConfig.OSLogLevel(
-        stringLiteral: value
-      )
+      let value = ClientConfig.OSLogLevel(stringLiteral: remoteValue)
       return value == .unknown ? nil : value
     default:
       return nil
@@ -131,7 +127,10 @@ extension ClientConfig {
     messages: inout PendingLogMessages
   ) {
     guard let validatedValue = value(forName: name) else {
-      messages.warning("", visibility: .public)
+      messages.warning(
+        "Could not read value for property: \(name)",
+        visibility: .public
+      )
       return
     }
     if !AnyHashable.areEqual(convertedValue, validatedValue) {

--- a/Sources/PromotedFirebaseRemoteConfig/ClientConfig+PromotedFirebaseRemoteConfig.swift
+++ b/Sources/PromotedFirebaseRemoteConfig/ClientConfig+PromotedFirebaseRemoteConfig.swift
@@ -105,11 +105,11 @@ extension ClientConfig {
     case is String:
       return remoteValue
     case is ClientConfig.MetricsLoggingWireFormat:
-      return ClientConfig.MetricsLoggingWireFormat(remoteValue)
+      return ClientConfig.MetricsLoggingWireFormat(remoteValue.toCamelCase())
     case is ClientConfig.XrayLevel:
-      return ClientConfig.XrayLevel(remoteValue)
+      return ClientConfig.XrayLevel(remoteValue.toCamelCase())
     case is ClientConfig.OSLogLevel:
-      return ClientConfig.OSLogLevel(remoteValue)
+      return ClientConfig.OSLogLevel(remoteValue.toCamelCase())
     default:
       return nil
     }
@@ -193,6 +193,18 @@ extension String {
       withTemplate: "$1_$2$3"
     )
     return result.lowercased()
+  }
+
+  func toCamelCase() -> String {
+    var first = true
+    return split(separator: "_")
+      .map { value in
+        let result = first ? value :
+          value.prefix(1).uppercased() + value.dropFirst()
+        first = false
+        return String(result)
+      }
+      .joined()
   }
 }
 

--- a/Sources/PromotedFirebaseRemoteConfig/ClientConfig+PromotedFirebaseRemoteConfig.swift
+++ b/Sources/PromotedFirebaseRemoteConfig/ClientConfig+PromotedFirebaseRemoteConfig.swift
@@ -105,11 +105,11 @@ extension ClientConfig {
     case is String:
       return remoteValue
     case is ClientConfig.MetricsLoggingWireFormat:
-      return ClientConfig.MetricsLoggingWireFormat(name: remoteValue)
+      return ClientConfig.MetricsLoggingWireFormat(remoteValue)
     case is ClientConfig.XrayLevel:
-      return ClientConfig.XrayLevel(name: remoteValue)
+      return ClientConfig.XrayLevel(remoteValue)
     case is ClientConfig.OSLogLevel:
-      return ClientConfig.OSLogLevel(name: remoteValue)
+      return ClientConfig.OSLogLevel(remoteValue)
     default:
       return nil
     }

--- a/Sources/PromotedFirebaseRemoteConfig/ClientConfig+PromotedFirebaseRemoteConfig.swift
+++ b/Sources/PromotedFirebaseRemoteConfig/ClientConfig+PromotedFirebaseRemoteConfig.swift
@@ -75,9 +75,9 @@ extension ClientConfig {
         visibility: .public
       )
 
-      self.setValue(convertedValue, forName: childLabel)
+      self.setValue(convertedValue, forKey: childLabel)
       checkValidatedValueChanged(
-        name: childLabel,
+        label: childLabel,
         dictionaryKey: key,
         convertedValue: convertedValue,
         messages: &messages
@@ -116,14 +116,14 @@ extension ClientConfig {
   }
 
   private func checkValidatedValueChanged<Value>(
-    name: String,
+    label: String,
     dictionaryKey: String,
     convertedValue: Value,
     messages: inout PendingLogMessages
   ) {
-    guard let validatedValue = value(forName: name) else {
+    guard let validatedValue = value(forKey: label) else {
       messages.warning(
-        "Could not read value for property: \(name)",
+        "Could not read value for property: \(label)",
         visibility: .public
       )
       return

--- a/Sources/PromotedFirebaseRemoteConfig/FirebaseRemoteConfigService.swift
+++ b/Sources/PromotedFirebaseRemoteConfig/FirebaseRemoteConfigService.swift
@@ -45,7 +45,7 @@ final class FirebaseRemoteConfigConnection: RemoteConfigConnection {
         resultMessages.info("Using prefetched config.", visibility: .public)
         fallthrough
       case .successFetchedFromRemote:
-        let config = ClientConfig(initialConfig)
+        var config = initialConfig
         config.merge(from: remoteConfig, messages: &resultMessages)
         resultConfig = config
         resultMessages.info(

--- a/Sources/PromotedMetrics/MetricsLoggerService+PromotedMetrics.swift
+++ b/Sources/PromotedMetrics/MetricsLoggerService+PromotedMetrics.swift
@@ -6,8 +6,11 @@ import PromotedCore
 
 public extension MetricsLoggerService {
 
-  @objc static func startServices(initialConfig: _ObjCClientConfig) throws {
-    try startServices(coreInitialConfig: ClientConfig(initialConfig))
+  @objc(startServicesWithInitialConfig:error:)
+  static func startServices(
+    objCInitialConfig: _ObjCClientConfig
+  ) throws {
+    try startServices(coreInitialConfig: ClientConfig(objCInitialConfig))
   }
 
   /// Call this to start logging services, prior to accessing `shared`.
@@ -21,8 +24,11 @@ public extension MetricsLoggerService {
     try startServices(moduleConfig: moduleConfig)
   }
 
-  @objc convenience init(initialConfig: _ObjCClientConfig) throws {
-    try self.init(initialConfig: ClientConfig(initialConfig))
+  @objc(initWithInitialConfig:error:)
+  convenience init(
+    objCInitialConfig: _ObjCClientConfig
+  ) throws {
+    try self.init(initialConfig: ClientConfig(objCInitialConfig))
   }
 
   /// Creates a new service with a core configuration.

--- a/Sources/PromotedMetrics/MetricsLoggerService+PromotedMetrics.swift
+++ b/Sources/PromotedMetrics/MetricsLoggerService+PromotedMetrics.swift
@@ -5,20 +5,29 @@ import PromotedCore
 #endif
 
 public extension MetricsLoggerService {
+
+  @objc static func startServices(initialConfig: _ObjCClientConfig) throws {
+    try startServices(coreInitialConfig: ClientConfig(initialConfig))
+  }
+
   /// Call this to start logging services, prior to accessing `shared`.
   /// Creates a default implementation for `NetworkConnection`.
   ///
   /// Equivalent to calling `init`, then `startLoggingServices()` on
   /// the shared service.
-  @objc static func startServices(initialConfig: ClientConfig) throws {
+  static func startServices(initialConfig: ClientConfig) throws {
     let moduleConfig = ModuleConfig.defaultConfig()
     moduleConfig.initialConfig = initialConfig
     try startServices(moduleConfig: moduleConfig)
   }
 
+  @objc convenience init(initialConfig: _ObjCClientConfig) throws {
+    try self.init(initialConfig: ClientConfig(initialConfig))
+  }
+
   /// Creates a new service with a core configuration.
   /// Creates a default implementation for `NetworkConnection`.
-  @objc convenience init(initialConfig: ClientConfig) throws {
+  convenience init(initialConfig: ClientConfig) throws {
     let moduleConfig = ModuleConfig.defaultConfig()
     moduleConfig.initialConfig = initialConfig
     try self.init(moduleConfig: moduleConfig)

--- a/Tests/PromotedCoreTests/AnalyticsTests.swift
+++ b/Tests/PromotedCoreTests/AnalyticsTests.swift
@@ -11,7 +11,7 @@ final class AnalyticsTests: ModuleTestCase {
 
   override func setUp() {
     super.setUp()
-    config.metricsLoggingURL = "http://fake.promoted.ai/metrics"
+    module.clientConfig.metricsLoggingURL = "http://fake.promoted.ai/metrics"
     clock.advance(to: 123)
     store.userID = "foobar"
     store.logUserID = "fake-log-user-id"

--- a/Tests/PromotedCoreTests/ClientConfigServiceTests.swift
+++ b/Tests/PromotedCoreTests/ClientConfigServiceTests.swift
@@ -7,13 +7,12 @@ import XCTest
 final class ClientConfigServiceTests: ModuleTestCase {
 
   func testLocalCache() {
-    let config = ClientConfig()
     let url = "https://fake.promoted.ai"
-    config.metricsLoggingURL = url
-    config.metricsLoggingAPIKey = "apikey!"
-    config.xrayLevel = .callDetails
+    module.clientConfig.metricsLoggingURL = url
+    module.clientConfig.metricsLoggingAPIKey = "apikey!"
+    module.clientConfig.xrayLevel = .callDetails
 
-    let configData = try! JSONEncoder().encode(config)
+    let configData = try! JSONEncoder().encode(module.clientConfig)
     store.clientConfig = configData
     module.clientConfigService.fetchClientConfig { _ in }
 
@@ -28,7 +27,7 @@ final class ClientConfigServiceTests: ModuleTestCase {
 
   func testCachesRemoteValue() {
     let url = "https://fake2.promoted.ai"
-    let remoteConfig = ClientConfig()
+    var remoteConfig = ClientConfig()
     remoteConfig.metricsLoggingURL = url
     remoteConfig.metricsLoggingAPIKey = "apikey!!"
     remoteConfig.xrayLevel = .callDetails

--- a/Tests/PromotedCoreTests/ClientConfigTests.swift
+++ b/Tests/PromotedCoreTests/ClientConfigTests.swift
@@ -6,25 +6,31 @@ import XCTest
 final class ClientConfigTests: XCTestCase {
 
   func testValue() {
-    let config = ClientConfig()
+    var config = ClientConfig()
+    config.disableAssertInValidationForTesting()
     let mirror = Mirror(reflecting: config)
     for child in mirror.children {
       guard let name = child.label else {
         XCTFail("Child with no label: \(String(describing: child))")
         return
       }
-      _ = config.value(forName: name)
+      if name == "assertInValidation" { continue }
+      XCTAssertNotNil(config.value(forName: name))
     }
   }
 
   func testSetValue() {
     var config = ClientConfig()
+    // Don't call config.disableAssertInValidationForTesting().
+    // If this test trips the assert, you need to add support
+    // for your new property in value()/setValue().
     let mirror = Mirror(reflecting: config)
     for child in mirror.children {
       guard let name = child.label else {
         XCTFail("Child with no label: \(String(describing: child))")
         return
       }
+      if name == "assertInValidation" { continue }
       config.setValue(child.value, forName: name)
     }
   }
@@ -66,7 +72,6 @@ final class ClientConfigTests: XCTestCase {
         $0[$1.label!] = String(describing: type(of: $1.value))
       }
 
-    XCTAssertEqual(swiftKeyToType.keys, objcKeyToType.keys)
     XCTAssertEqual(swiftKeyToType, objcKeyToType)
   }
 }

--- a/Tests/PromotedCoreTests/ClientConfigTests.swift
+++ b/Tests/PromotedCoreTests/ClientConfigTests.swift
@@ -16,15 +16,6 @@ final class ClientConfigTests: XCTestCase {
     var config = ClientConfig()
     config.disableAssertInValidationForTesting()
 
-    config.metricsLoggingWireFormat = .unknown
-    XCTAssertEqual(.binary, config.metricsLoggingWireFormat)
-
-    config.xrayLevel = .unknown
-    XCTAssertEqual(.none, config.xrayLevel)
-
-    config.osLogLevel = .unknown
-    XCTAssertEqual(.none, config.osLogLevel)
-
     config.setValue("invalid", forName: "metricsLoggingWireFormat")
     XCTAssertEqual(.binary, config.metricsLoggingWireFormat)
 

--- a/Tests/PromotedCoreTests/ClientConfigTests.swift
+++ b/Tests/PromotedCoreTests/ClientConfigTests.swift
@@ -5,6 +5,30 @@ import XCTest
 
 final class ClientConfigTests: XCTestCase {
 
+  func testValue() {
+    let config = ClientConfig()
+    let mirror = Mirror(reflecting: config)
+    for child in mirror.children {
+      guard let name = child.label else {
+        XCTFail("Child with no label: \(String(describing: child))")
+        return
+      }
+      _ = config.value(forName: name)
+    }
+  }
+
+  func testSetValue() {
+    var config = ClientConfig()
+    let mirror = Mirror(reflecting: config)
+    for child in mirror.children {
+      guard let name = child.label else {
+        XCTFail("Child with no label: \(String(describing: child))")
+        return
+      }
+      config.setValue(child.value, forName: name)
+    }
+  }
+
   func testBound() {
     var config = ClientConfig()
     config.disableAssertInValidationForTesting()

--- a/Tests/PromotedCoreTests/ClientConfigTests.swift
+++ b/Tests/PromotedCoreTests/ClientConfigTests.swift
@@ -49,4 +49,24 @@ final class ClientConfigTests: XCTestCase {
     config.setValue("invalid", forName: "osLogLevel")
     XCTAssertEqual(.none, config.osLogLevel)
   }
+
+  func testObjCFields() {
+    let swiftConfig = ClientConfig()
+    let swiftKeyToType = Mirror(reflecting: swiftConfig)
+      .children
+      .filter { $0.label != "assertInValidation" }
+      .reduce(into: [String: String]()) {
+        $0[$1.label!] = String(describing: type(of: $1.value))
+      }
+
+    let objcConfig = _ObjCClientConfig()
+    let objcKeyToType = Mirror(reflecting: objcConfig)
+      .children
+      .reduce(into: [String: String]()) {
+        $0[$1.label!] = String(describing: type(of: $1.value))
+      }
+
+    XCTAssertEqual(swiftKeyToType.keys, objcKeyToType.keys)
+    XCTAssertEqual(swiftKeyToType, objcKeyToType)
+  }
 }

--- a/Tests/PromotedCoreTests/ClientConfigTests.swift
+++ b/Tests/PromotedCoreTests/ClientConfigTests.swift
@@ -15,7 +15,7 @@ final class ClientConfigTests: XCTestCase {
         return
       }
       if name == "assertInValidation" { continue }
-      XCTAssertNotNil(config.value(forName: name))
+      XCTAssertNotNil(config.value(forKey: name))
     }
   }
 
@@ -31,7 +31,7 @@ final class ClientConfigTests: XCTestCase {
         return
       }
       if name == "assertInValidation" { continue }
-      config.setValue(child.value, forName: name)
+      config.setValue(child.value, forKey: name)
     }
   }
 
@@ -46,13 +46,13 @@ final class ClientConfigTests: XCTestCase {
     var config = ClientConfig()
     config.disableAssertInValidationForTesting()
 
-    config.setValue("invalid", forName: "metricsLoggingWireFormat")
+    config.setValue("invalid", forKey: "metricsLoggingWireFormat")
     XCTAssertEqual(.binary, config.metricsLoggingWireFormat)
 
-    config.setValue("invalid", forName: "xrayLevel")
+    config.setValue("invalid", forKey: "xrayLevel")
     XCTAssertEqual(.none, config.xrayLevel)
 
-    config.setValue("invalid", forName: "osLogLevel")
+    config.setValue("invalid", forKey: "osLogLevel")
     XCTAssertEqual(.none, config.osLogLevel)
   }
 

--- a/Tests/PromotedCoreTests/ClientConfigTests.swift
+++ b/Tests/PromotedCoreTests/ClientConfigTests.swift
@@ -55,4 +55,19 @@ final class ClientConfigTests: XCTestCase {
     config.setValue("invalid", forKey: "osLogLevel")
     XCTAssertEqual(.none, config.osLogLevel)
   }
+
+  func testPassByValue() {
+    var config1 = ClientConfig()
+    config1.metricsLoggingURL = "https://fake.promoted.ai/hippo/potamus"
+    var config2 = config1
+    config2.metricsLoggingURL = "https://fake.promoted.ai/rhino/cerous"
+    XCTAssertEqual(
+      "https://fake.promoted.ai/hippo/potamus",
+      config1.metricsLoggingURL
+    )
+    XCTAssertEqual(
+      "https://fake.promoted.ai/rhino/cerous",
+      config2.metricsLoggingURL
+    )
+  }
 }

--- a/Tests/PromotedCoreTests/ClientConfigTests.swift
+++ b/Tests/PromotedCoreTests/ClientConfigTests.swift
@@ -6,14 +6,14 @@ import XCTest
 final class ClientConfigTests: XCTestCase {
 
   func testBound() {
-    let config = ClientConfig()
+    var config = ClientConfig()
     config.disableAssertInValidationForTesting()
     config.loggingFlushInterval = -1.0
     XCTAssertEqual(1.0, config.loggingFlushInterval, accuracy: 0.001)
   }
 
   func testBadEnumValues() {
-    let config = ClientConfig()
+    var config = ClientConfig()
     config.disableAssertInValidationForTesting()
 
     config.metricsLoggingWireFormat = .unknown
@@ -25,15 +25,13 @@ final class ClientConfigTests: XCTestCase {
     config.osLogLevel = .unknown
     XCTAssertEqual(.none, config.osLogLevel)
 
-    // Use ObjC key-value coding to force invalid enum values.
-    // You should never do this normally.
-    config.setValue("invalid", forKey: "metricsLoggingWireFormat")
+    config.setValue("invalid", forName: "metricsLoggingWireFormat")
     XCTAssertEqual(.binary, config.metricsLoggingWireFormat)
 
-    config.setValue("invalid", forKey: "xrayLevel")
+    config.setValue("invalid", forName: "xrayLevel")
     XCTAssertEqual(.none, config.xrayLevel)
 
-    config.setValue("invalid", forKey: "osLogLevel")
+    config.setValue("invalid", forName: "osLogLevel")
     XCTAssertEqual(.none, config.osLogLevel)
   }
 }

--- a/Tests/PromotedCoreTests/ClientConfigTests.swift
+++ b/Tests/PromotedCoreTests/ClientConfigTests.swift
@@ -55,23 +55,4 @@ final class ClientConfigTests: XCTestCase {
     config.setValue("invalid", forKey: "osLogLevel")
     XCTAssertEqual(.none, config.osLogLevel)
   }
-
-  func testObjCFields() {
-    let swiftConfig = ClientConfig()
-    let swiftKeyToType = Mirror(reflecting: swiftConfig)
-      .children
-      .filter { $0.label != "assertInValidation" }
-      .reduce(into: [String: String]()) {
-        $0[$1.label!] = String(describing: type(of: $1.value))
-      }
-
-    let objcConfig = _ObjCClientConfig()
-    let objcKeyToType = Mirror(reflecting: objcConfig)
-      .children
-      .reduce(into: [String: String]()) {
-        $0[$1.label!] = String(describing: type(of: $1.value))
-      }
-
-    XCTAssertEqual(swiftKeyToType, objcKeyToType)
-  }
 }

--- a/Tests/PromotedCoreTests/MetricsLoggerTests.swift
+++ b/Tests/PromotedCoreTests/MetricsLoggerTests.swift
@@ -13,7 +13,7 @@ final class MetricsLoggerTests: ModuleTestCase {
 
   override func setUp() {
     super.setUp()
-    config.metricsLoggingURL = "http://fake.promoted.ai/metrics"
+    module.clientConfig.metricsLoggingURL = "http://fake.promoted.ai/metrics"
     clock.advance(to: 123)
     store.userID = "foobar"
     store.logUserID = "fake-log-user-id"

--- a/Tests/PromotedCoreTests/NetworkConnectionTests.swift
+++ b/Tests/PromotedCoreTests/NetworkConnectionTests.swift
@@ -8,7 +8,7 @@ import XCTest
 final class NetworkConnectionTests: ModuleTestCase {
 
   func testMetricsLoggingURL() {
-    let config = ClientConfig()
+    var config = ClientConfig()
     config.metricsLoggingURL = "http://fake.promoted.ai/prod"
     do {
       let url = try connection.metricsLoggingURL(clientConfig: config)
@@ -32,6 +32,7 @@ final class NetworkConnectionTests: ModuleTestCase {
     message.actionID = "foo"
     
     do {
+      var config = ClientConfig()
       config.metricsLoggingWireFormat = .json
       let jsonData = try connection.bodyData(message: message, clientConfig: config)
       let jsonString = String(data: jsonData, encoding: .utf8)!
@@ -46,6 +47,7 @@ final class NetworkConnectionTests: ModuleTestCase {
     message.actionID = "foo"
     
     do {
+      var config = ClientConfig()
       config.metricsLoggingWireFormat = .binary
       let binaryData = try connection.bodyData(message: message, clientConfig: config)
       XCTAssertGreaterThan(binaryData.count, 0)
@@ -55,6 +57,7 @@ final class NetworkConnectionTests: ModuleTestCase {
   }
     
   func testURLRequestAPIKey() {
+    var config = ClientConfig()
     config.metricsLoggingAPIKey = "key!"
     config.apiKeyHTTPHeaderField = "API_KEY"
     let url = URL(string: "http://promoted.ai")!

--- a/Tests/PromotedCoreTests/XrayTests.swift
+++ b/Tests/PromotedCoreTests/XrayTests.swift
@@ -11,7 +11,7 @@ final class XrayTests: ModuleTestCase {
   typealias Context = OperationMonitor.Context
   
   func testSingleBatch() {
-    config.xrayLevel = .callDetails
+    module.clientConfig.xrayLevel = .callDetails
     xray = Xray(deps: module)
 
     clock.advance(toMillis: 0)
@@ -81,7 +81,7 @@ final class XrayTests: ModuleTestCase {
   }
 
   func testBatchSummaries() {
-    config.xrayLevel = .batchSummaries
+    module.clientConfig.xrayLevel = .batchSummaries
     xray = Xray(deps: module)
 
     clock.advance(toMillis: 0)
@@ -126,7 +126,7 @@ final class XrayTests: ModuleTestCase {
   }
 
   func testCalls() {
-    config.xrayLevel = .callDetails
+    module.clientConfig.xrayLevel = .callDetails
     xray = Xray(deps: module)
 
     func callXray(_ function: String) -> Context {
@@ -155,7 +155,7 @@ final class XrayTests: ModuleTestCase {
   }
 
   func testErrors() {
-    config.xrayLevel = .callDetails
+    module.clientConfig.xrayLevel = .callDetails
     xray = Xray(deps: module)
 
     func batchXray(batchError: Error? = nil,
@@ -203,7 +203,7 @@ final class XrayTests: ModuleTestCase {
   }
 
   func testBatchSummariesErrors() {
-    config.xrayLevel = .batchSummaries
+    module.clientConfig.xrayLevel = .batchSummaries
     xray = Xray(deps: module)
 
     func batchXray(batchError: Error? = nil,

--- a/Tests/PromotedFirebaseRemoteConfigTests/ClientConfigMergeTests.swift
+++ b/Tests/PromotedFirebaseRemoteConfigTests/ClientConfigMergeTests.swift
@@ -147,7 +147,7 @@ final class ClientConfigMergeTests: XCTestCase {
 
     assertLoggedMessagesEqualNoOrder([
       (.warning, "Attempted to set invalid value: " +
-        "ai_promoted_logging_flush_interval = 0.0 (using 1.0 instead)"),
+        "ai_promoted_logging_flush_interval = 0.0 (using 1 instead)"),
       (.info, "Read from remote config: " +
         "ai_promoted_logging_flush_interval = 0.0"),
     ], messages)

--- a/Tests/PromotedFirebaseRemoteConfigTests/ClientConfigMergeTests.swift
+++ b/Tests/PromotedFirebaseRemoteConfigTests/ClientConfigMergeTests.swift
@@ -26,7 +26,7 @@ final class ClientConfigMergeTests: XCTestCase {
   }
 
   func testMerge() {
-    let config = ClientConfig()
+    var config = ClientConfig()
     config.disableAssertInValidationForTesting()
 
     let url = "https://fake2.promoted.ai/hippo/potamus"
@@ -51,9 +51,9 @@ final class ClientConfigMergeTests: XCTestCase {
       (.info, "Read from remote config: " +
         "ai_promoted_flush_logging_on_resign_active = false"),
       (.info, "Read from remote config: " +
-        "ai_promoted_xray_level = 2"),
+        "ai_promoted_xray_level = batchSummaries"),
       (.info, "Read from remote config: " +
-        "ai_promoted_os_log_level = 5"),
+        "ai_promoted_os_log_level = debug"),
     ], messages)
 
     // Changed values.
@@ -83,7 +83,7 @@ final class ClientConfigMergeTests: XCTestCase {
   }
 
   func testUnusedKey() {
-    let config = ClientConfig()
+    var config = ClientConfig()
     config.disableAssertInValidationForTesting()
 
     let url = "https://fake2.promoted.ai/hippo/potamus"
@@ -105,7 +105,7 @@ final class ClientConfigMergeTests: XCTestCase {
   }
 
   func testBadValues() {
-    let config = ClientConfig()
+    var config = ClientConfig()
     config.disableAssertInValidationForTesting()
 
     let url = "https://fake2.promoted.ai/hippo/potamus"
@@ -136,7 +136,7 @@ final class ClientConfigMergeTests: XCTestCase {
   }
 
   func testOutOfBoundsValues() {
-    let config = ClientConfig()
+    var config = ClientConfig()
     config.disableAssertInValidationForTesting()
 
     let dictionary = [
@@ -147,7 +147,7 @@ final class ClientConfigMergeTests: XCTestCase {
 
     assertLoggedMessagesEqualNoOrder([
       (.warning, "Attempted to set invalid value: " +
-        "ai_promoted_logging_flush_interval = 0.0 (using 1 instead)"),
+        "ai_promoted_logging_flush_interval = 0.0 (using 1.0 instead)"),
       (.info, "Read from remote config: " +
         "ai_promoted_logging_flush_interval = 0.0"),
     ], messages)

--- a/Tests/PromotedFirebaseRemoteConfigTests/StringCaseConversionTests.swift
+++ b/Tests/PromotedFirebaseRemoteConfigTests/StringCaseConversionTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import XCTest
+
+@testable import PromotedFirebaseRemoteConfig
+
+final class StringCaseConversionTests: XCTestCase {
+
+  func testSnakeCase() {
+    XCTAssertEqual("json", "json".toSnakeCase())
+    XCTAssertEqual("batch_summaries", "batchSummaries".toSnakeCase())
+    XCTAssertEqual(
+      "call_details_and_stack_traces",
+      "callDetailsAndStackTraces".toSnakeCase()
+    )
+  }
+
+  func testCamelCase() {
+    XCTAssertEqual("json", "json".toCamelCase())
+        XCTAssertEqual("batchSummaries", "batch_summaries".toCamelCase())
+        XCTAssertEqual(
+          "callDetailsAndStackTraces",
+          "call_details_and_stack_traces".toCamelCase()
+        )
+  }
+}


### PR DESCRIPTION
# Motivation

`ClientConfig` should really be a struct, not a class. It was a class previously due to Objective C compatibility, but this approach could lead to mis-use and bugs. This is a clean-up/infrastructure item that I'd like to take care of before releasing the SDK more broadly. 

Structs in Swift are pass-by-value, and have the following advantages when using them for objects that hold data:
 
1. Assignment always creates a copy, so after doing `b = a`, any changes to `a` do not affect `b`. This prevents clients from changing the `ClientConfig` after the logging session starts.
2. Read-only semantics are enforced by the compiler. That is, if you have a `let foo = FooStruct()`, then you cannot modify any of the fields in `foo` (ie. `foo.bar = "newValue"` will not compile). This makes it clear that clients can inspect a configuration object but not modify it. With classes, declaring a readonly object with `let foo = FooClass()` still allows you to modify its properties, such as `foo.bar = "newValue"`. (The readonly aspect only prevents you from reassigning the `foo` variable.)

These are difficult to achieve with classes. For 1, you need to make a copy of a class everywhere you want a local immutable instance of it. If you forget, and do a straight assignment without doing a copy, then this can cause difficult-to-diagnose bugs. For 2, you have to make a version of the class with immutable properties, which can duplicate a lot of code.

# Copy-on-write wrapper

To achieve the above with minimal boilerplate or duplicate code, we made a struct, `ClientConfig`, that wraps a class, `_ObjCClientConfig`. The struct exposes all the properties of the class directly via dynamic member lookup with key paths. This means you can do `config.foo` on the struct, and access the `foo` property in the class transparently.

The wrapped instance of the class is kept unique using copy-on-write semantics. This means that copying the struct and modifying the copy does not change the original.

This approach is somewhat unusual, but it has the following advantages.

1. Structs don't have access to `NSObject`'s key-value coding, so they're missing `value()` and `setValue()` methods. We use these methods when merging values from remote configs, so keeping the Objective C object around also preserves this functionality.
2. Gets us the advantages of the struct while maintaining Objective C compatibility.
3. Has a lot less boilerplate and duplicate code than other approaches that I investigated (see #142).

# ConfigEnums

Removed the `ExpressibleByStringLiteral` conformance since it wasn't buying us anything in the end. This brings the following improvements:

1. Don't need an `init(stringLiteral:)` initializer that has to return a non-nil value. Thus, we can introduce an `init?(_ name: String)` that can return nil for unsupported names, which is more idiomatic.
2. Don't need `unknown` values in the enums.
3. Less conversion code in `ClientConfig+PromotedFirebaseRemoteConfig`.

Also added defensive handling of invalid enum values, which resolve to a raw value of 0. Going forward, enums in `ClientConfig` should always have a case 0, and that case should be the default or a harmless value.