### PR TITLE
Fix AutoView ancestor ID history

### DIFF
--- a/Sources/PromotedCore/MetricsLogger/MetricsLogger+AutoView.swift
+++ b/Sources/PromotedCore/MetricsLogger/MetricsLogger+AutoView.swift
@@ -37,7 +37,7 @@ public extension MetricsLogger {
         autoView.idProvenances = i
       }
       log(message: autoView)
-      history?.autoViewIDDidChange(value: viewID, event: autoView)
+      history?.autoViewIDDidChange(value: autoViewID, event: autoView)
     }
     return autoView
   }

--- a/Sources/PromotedCore/MetricsLogger/MetricsLogger+Diagnostics.swift
+++ b/Sources/PromotedCore/MetricsLogger/MetricsLogger+Diagnostics.swift
@@ -37,7 +37,7 @@ extension MetricsLogger {
 
   private func mobileDiagnosticsMessage() -> Event_MobileDiagnostics {
     var diagnostics = Event_MobileDiagnostics()
-    if let id = UIDevice.current.identifierForVendor?.uuidString {
+    if let id = deviceInfo.identifierForVendor?.uuidString {
       diagnostics.deviceIdentifier = id
     }
     return diagnostics
@@ -141,6 +141,8 @@ fileprivate extension Deque where Element == Event_AncestorIdHistoryItem {
     }
     if let event = event {
       switch event {
+      case let autoView as Event_AutoView:
+        historyItem.autoViewEvent = autoView
       case let user as Event_User:
         historyItem.userEvent = user
       case let view as Event_View:

--- a/Sources/PromotedCore/MetricsLogger/MetricsLogger+View.swift
+++ b/Sources/PromotedCore/MetricsLogger/MetricsLogger+View.swift
@@ -63,7 +63,7 @@ public extension MetricsLogger {
         view.idProvenances = i
       }
       log(message: view)
-      history?.viewIDDidChange(value: viewID, event: view)
+      history?.viewIDDidChange(value: view.viewID, event: view)
     }
     return view
   }


### PR DESCRIPTION
- There was a bug in ancestor ID history diagnostics where we were not picking up autoViews correctly. This fixes that bug.
- Fixes bugs where the autoView ID and view IDs were not being recorded correctly in history.
- Replaces a usage of UIDevice with dependency injection.
- Add tests for ancestor ID history in MetricsLogger.
- Adds some convenience methods to the test.