### PR TITLE
PRO-1990 - Add ClientInfo to LogRequest

### DIFF
--- a/Sources/PromotedCore/MetricsLogger/MetricsLogger+EventFields.swift
+++ b/Sources/PromotedCore/MetricsLogger/MetricsLogger+EventFields.swift
@@ -72,4 +72,11 @@ extension MetricsLogger {
     if let id = logUserID { userInfo.logUserID = id }
     return userInfo
   }
+  
+  func clientInfoMessage() -> Common_ClientInfo {
+    var clientInfo = Common_ClientInfo()
+    clientInfo.clientType = Common_ClientInfo.ClientType.platformClient
+    clientInfo.trafficType = Common_ClientInfo.TrafficType.production
+    return clientInfo
+  }
 }

--- a/Sources/PromotedCore/MetricsLogger/MetricsLogger+EventFields.swift
+++ b/Sources/PromotedCore/MetricsLogger/MetricsLogger+EventFields.swift
@@ -74,9 +74,12 @@ extension MetricsLogger {
   }
   
   func clientInfoMessage() -> Common_ClientInfo {
-    var clientInfo = Common_ClientInfo()
-    clientInfo.clientType = Common_ClientInfo.ClientType.platformClient
-    clientInfo.trafficType = Common_ClientInfo.TrafficType.production
-    return clientInfo
+    if cachedClientInfoMessage == nil {
+      var clientInfo = Common_ClientInfo()
+      clientInfo.clientType = Common_ClientInfo.ClientType.platformClient
+      clientInfo.trafficType = Common_ClientInfo.TrafficType.production
+      cachedClientInfoMessage = clientInfo
+    }
+    return cachedClientInfoMessage!
   }
 }

--- a/Sources/PromotedCore/MetricsLogger/MetricsLogger+EventFields.swift
+++ b/Sources/PromotedCore/MetricsLogger/MetricsLogger+EventFields.swift
@@ -76,8 +76,8 @@ extension MetricsLogger {
   func clientInfoMessage() -> Common_ClientInfo {
     if cachedClientInfoMessage == nil {
       var clientInfo = Common_ClientInfo()
-      clientInfo.clientType = Common_ClientInfo.ClientType.platformClient
-      clientInfo.trafficType = Common_ClientInfo.TrafficType.production
+      clientInfo.clientType = .platformClient
+      clientInfo.trafficType = .production
       cachedClientInfoMessage = clientInfo
     }
     return cachedClientInfoMessage!

--- a/Sources/PromotedCore/MetricsLogger/MetricsLogger.swift
+++ b/Sources/PromotedCore/MetricsLogger/MetricsLogger.swift
@@ -408,6 +408,7 @@ public extension MetricsLogger {
   
   private func logRequestMessage(events: [Message]) -> Event_LogRequest {
     var logRequest = Event_LogRequest()
+    logRequest.clientInfo = clientInfoMessage()
     logRequest.userInfo = userInfoMessage()
     logRequest.device = deviceMessage()
     for event in events {

--- a/Sources/PromotedCore/MetricsLogger/MetricsLogger.swift
+++ b/Sources/PromotedCore/MetricsLogger/MetricsLogger.swift
@@ -101,6 +101,7 @@ public final class MetricsLogger: NSObject {
 
   var cachedDeviceMessage: Common_Device?
   var cachedLocaleMessage: Common_Locale?
+  var cachedClientInfoMessage: Common_ClientInfo?
 
   typealias Deps = (
     BuildInfoSource &

--- a/Tests/PromotedCoreTests/ImpressionTrackerTests.swift
+++ b/Tests/PromotedCoreTests/ImpressionTrackerTests.swift
@@ -89,6 +89,10 @@ final class ImpressionTrackerTests: ModuleTestCase {
     let eventJSONJoined = eventJSONArray.joined(separator: ",")
     let expectedLogRequestJSON = """
     {
+      "client_info": {
+          "client_type": 2,
+          "traffic_type": 1
+      },
       "user_info": {
         "user_id": "foo",
         "log_user_id": "fake-log-user-id"

--- a/Tests/PromotedCoreTests/MetricsLoggerTests.swift
+++ b/Tests/PromotedCoreTests/MetricsLoggerTests.swift
@@ -404,6 +404,10 @@ final class MetricsLoggerTests: ModuleTestCase {
     XCTAssertTrue(message is Event_LogRequest)
     let expectedJSON = """
     {
+      "client_info": {
+        "client_type": 2,
+        "traffic_type": 1
+      },
       "user_info": {
         "log_user_id": "batman"
       },
@@ -437,6 +441,10 @@ final class MetricsLoggerTests: ModuleTestCase {
     XCTAssertTrue(message is Event_LogRequest)
     let expectedJSON = """
     {
+      "client_info": {
+        "client_type": 2,
+        "traffic_type": 1
+      },
       "user_info": {
         "log_user_id": "batman"
       },
@@ -1292,6 +1300,10 @@ final class MetricsLoggerTests: ModuleTestCase {
     XCTAssertTrue(message is Event_LogRequest)
     let expectedJSON = """
     {
+      "client_info": {
+        "client_type": 2,
+        "traffic_type": 1
+      },
       "user_info": {
         "log_user_id": "batman"
       },


### PR DESCRIPTION
This PR adds a `Common_ClientInfo` object to `LogRequest` using the same values as Android