### PR TITLE
Introduce PROMOTED_ERROR_HANDLING build flag

### DIFF
--- a/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
@@ -317,7 +317,7 @@ public final class _ObjCClientConfig: NSObject {
     /// useful for React Native apps.
     case breakInDebugger = 2
 
-    #if DEBUG
+    #if DEBUG || PROMOTED_ERROR_HANDLING
     static let `default`: MetricsLoggingErrorHandling = .modalDialog
     #else
     static let `default`: MetricsLoggingErrorHandling = .none

--- a/Sources/PromotedCore/ErrorHandling/ErrorDetails.swift
+++ b/Sources/PromotedCore/ErrorHandling/ErrorDetails.swift
@@ -1,4 +1,4 @@
-#if DEBUG
+#if DEBUG || PROMOTED_ERROR_HANDLING
 import Foundation
 
 /** Provides details for the ErrorHandlerVC. Public for ReactNativeMetrics. */

--- a/Sources/PromotedCore/ErrorHandling/ErrorHandler.swift
+++ b/Sources/PromotedCore/ErrorHandling/ErrorHandler.swift
@@ -44,7 +44,7 @@ class ErrorHandler: OperationMonitorListener {
     case .none:
       break
     case .modalDialog:
-      #if DEBUG
+      #if DEBUG || PROMOTED_ERROR_HANDLING
       if shouldShowModal {
         DispatchQueue.main.async { [weak self] in
           guard let self = self else { return }
@@ -83,7 +83,7 @@ protocol ErrorHandlerSource {
   var errorHandler: ErrorHandler? { get }
 }
 
-#if DEBUG
+#if DEBUG || PROMOTED_ERROR_HANDLING
 extension ErrorHandler: ErrorModalViewControllerDelegate {
   func errorModalVCDidDismiss(
     _ vc: ErrorModalViewController,

--- a/Sources/PromotedCore/ErrorHandling/ErrorModalViewController.swift
+++ b/Sources/PromotedCore/ErrorHandling/ErrorModalViewController.swift
@@ -1,4 +1,4 @@
-#if DEBUG
+#if DEBUG || PROMOTED_ERROR_HANDLING
 
 import Foundation
 import UIKit


### PR DESCRIPTION
This flag allows clients to include error handling in build configs of their choosing, so that error handling can be active in non-debug builds. We'll use this build flag pattern for similar internal tools in the future.