### PR TITLE
Add build flag support for error handling

### DIFF
--- a/PromotedAIMetricsSDK.podspec
+++ b/PromotedAIMetricsSDK.podspec
@@ -30,6 +30,7 @@ Pod::Spec.new do |s|
     core.resource_bundles = {
       "PromotedCore" => ['Sources/PromotedCore/Resources/*']
     }
+    core.preserve_path = 'promoted_features.rb'
   end
 
   s.subspec 'Fetcher' do |fetcher|

--- a/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
+++ b/Sources/PromotedCore/ClientConfig/_ObjCClientConfig.swift
@@ -317,7 +317,7 @@ public final class _ObjCClientConfig: NSObject {
     /// useful for React Native apps.
     case breakInDebugger = 2
 
-    #if DEBUG
+    #if DEBUG || PROMOTED_ERROR_HANDLING
     static let `default`: MetricsLoggingErrorHandling = .modalDialog
     #else
     static let `default`: MetricsLoggingErrorHandling = .none

--- a/Sources/PromotedCore/ErrorHandling/ErrorDetails.swift
+++ b/Sources/PromotedCore/ErrorHandling/ErrorDetails.swift
@@ -1,4 +1,4 @@
-#if DEBUG
+#if DEBUG || PROMOTED_ERROR_HANDLING
 import Foundation
 
 /** Provides details for the ErrorHandlerVC. Public for ReactNativeMetrics. */

--- a/Sources/PromotedCore/ErrorHandling/ErrorHandler.swift
+++ b/Sources/PromotedCore/ErrorHandling/ErrorHandler.swift
@@ -44,7 +44,7 @@ class ErrorHandler: OperationMonitorListener {
     case .none:
       break
     case .modalDialog:
-      #if DEBUG
+      #if DEBUG || PROMOTED_ERROR_HANDLING
       if shouldShowModal {
         DispatchQueue.main.async { [weak self] in
           guard let self = self else { return }
@@ -83,7 +83,7 @@ protocol ErrorHandlerSource {
   var errorHandler: ErrorHandler? { get }
 }
 
-#if DEBUG
+#if DEBUG || PROMOTED_ERROR_HANDLING
 extension ErrorHandler: ErrorModalViewControllerDelegate {
   func errorModalVCDidDismiss(
     _ vc: ErrorModalViewController,

--- a/Sources/PromotedCore/ErrorHandling/ErrorModalViewController.swift
+++ b/Sources/PromotedCore/ErrorHandling/ErrorModalViewController.swift
@@ -1,4 +1,4 @@
-#if DEBUG
+#if DEBUG || PROMOTED_ERROR_HANDLING
 
 import Foundation
 import UIKit

--- a/promoted_features.rb
+++ b/promoted_features.rb
@@ -1,0 +1,27 @@
+# Extra features that can be enabled for a CocoaPods project.
+# Promoted includes debugging and introspection tools that you may wish
+# to include in internal, non-debug builds, but not in release. These
+# functions allow you to specify which build targets in which to include
+# these features, to guarantee that they don't appear in release builds.
+
+require 'pp'
+
+def _use_promoted_build_flag(installer, build_configurations: [], build_flag: '')
+  installer.pods_project.targets.each do |target|
+    next unless target.name == 'PromotedAIMetricsSDK' or target.name == 'react-native-metrics'
+    target.build_configurations.each do |config|
+      next unless build_configurations.include? config.name
+      config.build_settings['OTHER_SWIFT_FLAGS'] ||= ['$(inherited)']
+      config.build_settings['OTHER_SWIFT_FLAGS'] << '-D'
+      config.build_settings['OTHER_SWIFT_FLAGS'] << build_flag
+    end
+  end
+end
+
+def use_promoted_error_handling(installer, build_configurations: [])
+  _use_promoted_build_flag(
+    installer,
+    build_configurations: build_configurations,
+    build_flag: 'PROMOTED_ERROR_HANDLING'
+  )
+end

--- a/promoted_features.rb
+++ b/promoted_features.rb
@@ -18,6 +18,19 @@ def _use_promoted_build_flag(installer, build_configurations: [], build_flag: ''
   end
 end
 
+# Call this in your Podfile to enable Promoted error handling in the
+# specified build configurations. For example:
+# ```
+# target 'myapp' do
+#   post_install do |installer|
+#     # Enables error handling in build config 'InternalBuild'
+#     use_promoted_error_handling(
+#       installer,
+#       build_configurations: ['InternalBuild']
+#     )
+#   end
+# end
+# ```
 def use_promoted_error_handling(installer, build_configurations: [])
   _use_promoted_build_flag(
     installer,


### PR DESCRIPTION
When clients want to enable error handling in a non-debug build, they can define a Swift compile flag called `PROMOTED_ERROR_HANDLING`.

This can also be done from a Cocoapod target like this:

```ruby
target 'myapp' do
  post_install do |installer|
    # Enables error handling in build config 'InternalBuild'
    use_promoted_error_handling(
      installer,
      build_configurations: ['InternalBuild']
    )
  end
end
```

This PR adds the build flag and the `use_promoted_error_handling` utility function.