### PR TITLE
feat: always send http request "content-type" header

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -5,10 +5,8 @@ on:
 
 jobs:
   pod-lib-lint:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Select Xcode version
-      run: sudo xcode-select -s '/Applications/Xcode_13.2.app/Contents/Developer'
     - name: Lint
       run: pod lib lint --verbose

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   pod-lib-lint:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
     - name: Lint

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -9,5 +9,9 @@ jobs:
     runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
+    - name: Set up Xcode
+      uses: actions/setup-xcode@v1
+      with:
+        xcode-version: 13.2.1
     - name: Lint
       run: pod lib lint --verbose

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -9,9 +9,7 @@ jobs:
     runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Xcode
-      uses: actions/setup-xcode@v1
-      with:
-        xcode-version: 13.2.1
+    - name: Select Xcode version
+      run: sudo xcode-select -s '/Applications/Xcode_13.2.app/Contents/Developer'
     - name: Lint
       run: pod lib lint --verbose

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -2,7 +2,6 @@ name: cocoapods
 
 on:
   push:
-  pull_request:
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -2,9 +2,7 @@ name: cocoapods
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/cocoapods_deploy.yml
+++ b/.github/workflows/cocoapods_deploy.yml
@@ -2,6 +2,7 @@ name: cocoapods_deploy
 
 on:
   push:
+    branches: [ main ]
     tags:
       - '*'
 

--- a/.github/workflows/cocoapods_deploy.yml
+++ b/.github/workflows/cocoapods_deploy.yml
@@ -2,7 +2,6 @@ name: cocoapods_deploy
 
 on:
   push:
-    branches: [ main ]
     tags:
       - '*'
 

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
     - name: Build

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -2,15 +2,12 @@ name: swiftpm
 
 on:
   push:
-  pull_request:
 
 jobs:
   build-and-test:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Select Xcode version
-      run: sudo xcode-select -s '/Applications/Xcode_13.2.app/Contents/Developer'
     - name: Build
       run: xcodebuild -scheme PromotedAIMetricsSDK-Package build -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 13'
     - name: Test

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
+    - name: Set up Xcode
+      uses: actions/setup-xcode@v1
+      with:
+        xcode-version: 13.2.1
     - name: Build
       run: xcodebuild -scheme PromotedAIMetricsSDK-Package build -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 13'
     - name: Test

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -2,9 +2,7 @@ name: swiftpm
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   build-and-test:

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -9,10 +9,8 @@ jobs:
     runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Xcode
-      uses: actions/setup-xcode@v1
-      with:
-        xcode-version: 13.2.1
+    - name: Select Xcode version
+      run: sudo xcode-select -s '/Applications/Xcode_13.2.app/Contents/Developer'
     - name: Build
       run: xcodebuild -scheme PromotedAIMetricsSDK-Package build -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 13'
     - name: Test

--- a/Sources/PromotedCore/NetworkConnection.swift
+++ b/Sources/PromotedCore/NetworkConnection.swift
@@ -86,9 +86,10 @@ public extension NetworkConnection {
       request.addValue(apiKey, forHTTPHeaderField: "x-api-key")
     }
     if (request.value(forHTTPHeaderField: "content-type") == nil) {
-      guard let contentTypeValue = try contentType(clientConfig: clientConfig)
+      guard
+        let contentTypeValue = contentType(clientConfig: clientConfig)
       else {
-        throw ClientConfigError.invalidMetricsLoggingWireFormat()
+        throw ClientConfigError.invalidMetricsLoggingWireFormat
       }
       request.addValue(
         contentTypeValue,

--- a/Sources/PromotedCore/NetworkConnection.swift
+++ b/Sources/PromotedCore/NetworkConnection.swift
@@ -85,17 +85,24 @@ public extension NetworkConnection {
     if !apiKey.isEmpty {
       request.addValue(apiKey, forHTTPHeaderField: "x-api-key")
     }
-    if (
-      clientConfig.metricsLoggingWireFormat == .binary &&
-      clientConfig.metricsLoggingURL.contains(".promoted.ai") &&
-      request.value(forHTTPHeaderField: "content-type") == nil
-    ) {
+    if (request.value(forHTTPHeaderField: "content-type") == nil) {
       request.addValue(
-        "application/protobuf",
+        contentType(clientConfig),
         forHTTPHeaderField: "content-type"
       )
     }
     return request
+  }
+
+  func contentType(
+      clientConfig: ClientConfig
+    ) throws -> String {
+      switch clientConfig.metricsLoggingWireFormat {
+      case .binary:
+        return "application/protobuf"
+      case .json:
+        return "application/json"
+      }
   }
 }
 

--- a/Sources/PromotedCore/NetworkConnection.swift
+++ b/Sources/PromotedCore/NetworkConnection.swift
@@ -86,11 +86,7 @@ public extension NetworkConnection {
       request.addValue(apiKey, forHTTPHeaderField: "x-api-key")
     }
     if (request.value(forHTTPHeaderField: "content-type") == nil) {
-      guard
-        let contentTypeValue = contentType(clientConfig: clientConfig)
-      else {
-        throw ClientConfigError.invalidMetricsLoggingWireFormat
-      }
+      let contentTypeValue = contentType(clientConfig: clientConfig)
       request.addValue(
         contentTypeValue,
         forHTTPHeaderField: "content-type"
@@ -100,14 +96,14 @@ public extension NetworkConnection {
   }
 
   func contentType(
-      clientConfig: ClientConfig
-    ) throws -> String {
-      switch clientConfig.metricsLoggingWireFormat {
-      case .binary:
-        return "application/protobuf"
-      case .json:
-        return "application/json"
-      }
+    clientConfig: ClientConfig
+  ) -> String {
+    switch clientConfig.metricsLoggingWireFormat {
+    case .binary:
+      return "application/protobuf"
+    case .json:
+      return "application/json"
+    }
   }
 }
 

--- a/Sources/PromotedCore/NetworkConnection.swift
+++ b/Sources/PromotedCore/NetworkConnection.swift
@@ -86,8 +86,12 @@ public extension NetworkConnection {
       request.addValue(apiKey, forHTTPHeaderField: "x-api-key")
     }
     if (request.value(forHTTPHeaderField: "content-type") == nil) {
+      guard let contentTypeValue = try contentType(clientConfig: clientConfig)
+      else {
+        throw ClientConfigError.invalidMetricsLoggingWireFormat()
+      }
       request.addValue(
-        contentType(clientConfig: clientConfig),
+        contentTypeValue,
         forHTTPHeaderField: "content-type"
       )
     }

--- a/Sources/PromotedCore/NetworkConnection.swift
+++ b/Sources/PromotedCore/NetworkConnection.swift
@@ -87,7 +87,7 @@ public extension NetworkConnection {
     }
     if (request.value(forHTTPHeaderField: "content-type") == nil) {
       request.addValue(
-        contentType(clientConfig),
+        contentType(clientConfig: clientConfig),
         forHTTPHeaderField: "content-type"
       )
     }


### PR DESCRIPTION
I don't know why we didn't always send through "content-type" header.

This PR also tries to fix GitHub Action configs.  "macos-latest" uses a version of macos that fails the GHA.

TESTING=Iterated on GHA.  I'm iterating on the test.